### PR TITLE
Fix tracer.Inject(..., HTTPHeadersWriter&) (#107)

### DIFF
--- a/src/jaegertracing/Tracer.h
+++ b/src/jaegertracing/Tracer.h
@@ -148,7 +148,7 @@ class Tracer : public opentracing::Tracer,
             return opentracing::make_expected_from_error<void>(
                 opentracing::invalid_span_context_error);
         }
-        _textPropagator.inject(*jaegerCtx, writer);
+        _httpHeaderPropagator.inject(*jaegerCtx, writer);
         return opentracing::make_expected();
     }
 

--- a/src/jaegertracing/TracerTest.cpp
+++ b/src/jaegertracing/TracerTest.cpp
@@ -327,7 +327,7 @@ TEST(Tracer, testPropagation)
         std::ostringstream oss;
         oss << span->context();
         ASSERT_EQ(oss.str(), headerMap.at(kTraceContextHeaderName));
-        ASSERT_EQ("test baggage item value",
+        ASSERT_EQ("test%20baggage%20item%20value",
                   headerMap.at(std::string(kTraceBaggageHeaderPrefix) +
                                "test-baggage-item-key"));
         ReaderMock<opentracing::HTTPHeadersReader> headerReader(headerMap);


### PR DESCRIPTION
tracer.Inject(SpanContext&, HTTPHeadersWriter&) was using the underlying
TextMapPropagator (instead of HTTPHeaderPropagator). This caused
injected baggage values not to be encoded.

Signed-off-by: Hugo Fernandes <hugof225@gmail.com>