### PR TITLE
Improve C++ flag handling in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,18 @@ HunterGate(
 
 project(jaegertracing VERSION 0.5.0)
 
+option(JAEGERTRACING_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -pedantic")
+  set(cxx_flags -Wall -pedantic)
+  if(JAEGERTRACING_WARNINGS_AS_ERRORS)
+    list(APPEND cxx_flags -Werror)
+  endif()
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
+  list(APPEND cxx_flags -Wno-unused-private-field)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -91,7 +96,8 @@ if(BUILD_TESTING)
 
   if(JAEGERTRACING_COVERAGE)
       include(CodeCoverage)
-      append_coverage_compiler_flags()
+      append_coverage_compiler_flags(cxx_flags)
+      append_coverage_compiler_flags(link_flags)
       set(COVERAGE_EXCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/src/jaegertracing/thrift-gen/*"
                             "*Test.cpp")
   endif()
@@ -200,7 +206,8 @@ function(add_lib_deps lib)
   target_include_directories(${lib} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)
-  target_link_libraries(${lib} PUBLIC ${LIBS})
+  target_link_libraries(${lib} PUBLIC ${link_flags} ${LIBS})
+  target_compile_options(${lib} PUBLIC ${cxx_flags})
 endfunction()
 
 option(JAEGERTRACING_PLUGIN "Build dynamic plugin" OFF)

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -82,13 +82,14 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
     if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
         message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
     endif()
-    set(COVERAGE_COMPILER_FLAGS "-Qunused-arguments")
+    list(APPEND COVERAGE_COMPILER_FLAGS -Qunused-arguments)
 elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
     message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
 endif()
 
-set(COVERAGE_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage"
-    CACHE INTERNAL "")
+list(APPEND COVERAGE_COMPILER_FLAGS
+     -g -O0 --coverage -fprofile-arcs -ftest-coverage)
+set(COVERAGE_COMPILER_FLAGS ${COVERAGE_COMPILER_FLAGS} CACHE INTERNAL "")
 
 set(CMAKE_CXX_FLAGS_COVERAGE
     ${COVERAGE_COMPILER_FLAGS}
@@ -174,8 +175,6 @@ function(setup_target_for_coverage)
     )
 endfunction() # setup_target_for_coverage
 
-function(append_coverage_compiler_flags)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
-    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+function(append_coverage_compiler_flags flags_var)
+    set(${flags_var} ${${flags_var}} ${COVERAGE_COMPILER_FLAGS} PARENT_SCOPE)
 endfunction() # append_coverage_compiler_flags


### PR DESCRIPTION
Minor improvement. Will be useful for debugging race conditions by easily adding thread sanitizer flags, etc.