### PR TITLE
localIP: try resolving local hostname first

### DIFF
--- a/src/jaegertracing/net/IPAddress.cpp
+++ b/src/jaegertracing/net/IPAddress.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "jaegertracing/net/IPAddress.h"
+#include "jaegertracing/platform/Hostname.h"
 
 #include <ifaddrs.h>
 #include <sys/types.h>
@@ -36,6 +37,12 @@ struct IfAddrDeleter : public std::function<void(ifaddrs*)> {
 
 IPAddress IPAddress::localIP(int family)
 {
+    try {
+        return versionFromString(platform::hostname(), 0, family);
+    } catch (const std::exception& e) {
+        // Fall back to returning the first matching interface
+    }
+
     return localIP([family](const ifaddrs* ifAddr) {
         return ifAddr->ifa_addr != nullptr &&
                ifAddr->ifa_addr->sa_family == family;

--- a/src/jaegertracing/net/IPAddress.cpp
+++ b/src/jaegertracing/net/IPAddress.cpp
@@ -39,7 +39,7 @@ IPAddress IPAddress::localIP(int family)
 {
     try {
         return versionFromString(platform::hostname(), 0, family);
-    } catch (const std::exception& e) {
+    } catch (...) {
         // Fall back to returning the first matching interface
     }
 


### PR DESCRIPTION
Fixes #129.

Signed-off-by: Tudor Bosman <tudor@rockset.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #129 

## Short description of the changes
- Just like the Jaeger Java client does, resolve the local hostname in order to determine the local IP address (to populate the "ip" tracer tag with).
