### PR TITLE
Change sampler param sentinel value from YAML parser

### DIFF
--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -73,6 +73,18 @@ TEST(Config, testDefaultSamplingProbability)
               Config().sampler().param());
 }
 
+TEST(Config, testZeroSamplingParam)
+{
+    {
+        constexpr auto kConfigYAML = R"cfg(
+sampler:
+    param: 0
+)cfg";
+        const auto config = Config::parse(YAML::Load(kConfigYAML));
+        ASSERT_EQ(0, config.sampler().param());
+    }
+}
+
 #endif  // JAEGERTRACING_WITH_YAML_CPP
 
 }  // namespace jaegertracing

--- a/src/jaegertracing/samplers/Config.h
+++ b/src/jaegertracing/samplers/Config.h
@@ -61,7 +61,7 @@ class Config {
         const auto type =
             utils::yaml::findOrDefault<std::string>(configYAML, "type", "");
         const auto param =
-            utils::yaml::findOrDefault<double>(configYAML, "param", 0);
+            utils::yaml::findOrDefault<double>(configYAML, "param", -1);
         const auto samplingServerURL = utils::yaml::findOrDefault<std::string>(
             configYAML, "samplingServerURL", "");
         const auto maxOperations =
@@ -86,7 +86,7 @@ class Config {
         const Clock::duration& samplingRefreshInterval =
             defaultSamplingRefreshInterval())
         : _type(type.empty() ? kSamplerTypeRemote : type)
-        , _param(param == 0 ? kDefaultSamplingProbability : param)
+        , _param(param == -1 ? kDefaultSamplingProbability : param)
         , _samplingServerURL(samplingServerURL.empty()
                                  ? kDefaultSamplingServerURL
                                  : samplingServerURL)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #144

## Short description of the changes
- Instead of using 0 as the sentinel value for an unspecified sampler param, use another number that would be illegal instead. This allows param = 0 to be specified and respected by samplers.
