### PR TITLE
Throw exception on invalid sampling rate

### DIFF
--- a/src/jaegertracing/samplers/Config.h
+++ b/src/jaegertracing/samplers/Config.h
@@ -122,6 +122,7 @@ class Config {
                 oss << "Invalid parameter for probabilistic sampler: " << _param
                     << ", expecting value between 0 and 1";
                 logger.error(oss.str());
+                throw std::invalid_argument("Probabilistic sampling rate should be in the interval [0, 1].");
                 return std::unique_ptr<Sampler>();
             }
         }

--- a/src/jaegertracing/samplers/SamplerTest.cpp
+++ b/src/jaegertracing/samplers/SamplerTest.cpp
@@ -20,6 +20,7 @@
 
 #include "jaegertracing/Constants.h"
 #include "jaegertracing/Tag.h"
+#include "jaegertracing/samplers/Config.h"
 #include "jaegertracing/samplers/AdaptiveSampler.h"
 #include "jaegertracing/samplers/ConstSampler.h"
 #include "jaegertracing/samplers/GuaranteedThroughputProbabilisticSampler.h"
@@ -147,6 +148,26 @@ TEST(Sampler, testProbabilisticSamplerPerformance)
     }
     const auto rate = static_cast<double>(count) / kNumSamples;
     std::cout << "Sampled: " << count << " rate=" << rate << '\n';
+}
+
+TEST(Sampler, testProbabilisticSamplerInvalidRate)
+{
+    Config samplerConfig1(kSamplerTypeProbabilistic,
+                          1.1,
+                          "",
+                          0,
+                          samplers::Config::Clock::duration());
+    Config samplerConfig2(kSamplerTypeProbabilistic,
+                          -0.1,
+                          "",
+                          0,
+                          samplers::Config::Clock::duration());
+    auto logger = logging::nullLogger();
+    auto metrics = metrics::Metrics::makeNullMetrics();
+    ASSERT_THROW(samplerConfig1.makeSampler("test-service", *logger, *metrics),
+                 std::invalid_argument);
+    ASSERT_THROW(samplerConfig2.makeSampler("test-service", *logger, *metrics),
+                 std::invalid_argument);
 }
 
 TEST(Sampler, testRateLimitingSampler)


### PR DESCRIPTION
Throw std::invalid_argument when the sampling rate is in the inclusive interval [0, 1] (#149)

## Which problem is this PR solving?

Resolves #149

- When Probabilistic Sampler with an invalid rate is used (< 0 or > 1), a crash occurs when a span is created. 

## Short description of the changes
- An std::invalid_argument exception is thrown when building a Probabilistic Sampler with an invalid rate.
