### PR TITLE
Remove Thrift headers from Jaeger public headers

### DIFF
--- a/src/jaegertracing/LogRecord.cpp
+++ b/src/jaegertracing/LogRecord.cpp
@@ -15,3 +15,25 @@
  */
 
 #include "jaegertracing/LogRecord.h"
+#include "jaegertracing/thrift-gen/jaeger_types.h"
+
+namespace jaegertracing {
+void LogRecord::thrift(thrift::Log& log) const
+{
+    log.__set_timestamp(std::chrono::duration_cast<std::chrono::microseconds>(
+                            _timestamp.time_since_epoch())
+                            .count());
+
+    std::vector<thrift::Tag> fields;
+    fields.reserve(_fields.size());
+    std::transform(std::begin(_fields),
+                   std::end(_fields),
+                   std::back_inserter(fields),
+                   [](const Tag& tag) {
+                       thrift::Tag thriftTag;
+                       tag.thrift(thriftTag);
+                       return thriftTag;
+                   });
+    log.__set_fields(fields);
+}
+}  // namespace jaegertracing

--- a/src/jaegertracing/LogRecord.h
+++ b/src/jaegertracing/LogRecord.h
@@ -19,7 +19,6 @@
 
 #include "jaegertracing/Compilers.h"
 #include "jaegertracing/Tag.h"
-#include "jaegertracing/thrift-gen/jaeger_types.h"
 #include <algorithm>
 #include <chrono>
 #include <iterator>
@@ -29,6 +28,9 @@
 #include <opentracing/span.h>
 
 namespace jaegertracing {
+namespace thrift {
+class Log;
+}
 
 class LogRecord {
   public:
@@ -48,9 +50,9 @@ class LogRecord {
     {
     }
 
-    LogRecord(const opentracing::LogRecord & other)
-        : _timestamp(other.timestamp),
-          _fields(other.fields.begin(), other.fields.end())
+    LogRecord(const opentracing::LogRecord& other)
+        : _timestamp(other.timestamp)
+        , _fields(other.fields.begin(), other.fields.end())
     {
     }
 
@@ -58,24 +60,7 @@ class LogRecord {
 
     const std::vector<Tag>& fields() const { return _fields; }
 
-    thrift::Log thrift() const
-    {
-        thrift::Log log;
-        log.__set_timestamp(
-            std::chrono::duration_cast<std::chrono::microseconds>(
-                _timestamp.time_since_epoch())
-                .count());
-
-        std::vector<thrift::Tag> fields;
-        fields.reserve(_fields.size());
-        std::transform(std::begin(_fields),
-                       std::end(_fields),
-                       std::back_inserter(fields),
-                       [](const Tag& tag) { return tag.thrift(); });
-        log.__set_fields(fields);
-
-        return log;
-    }
+    void thrift(thrift::Log& log) const;
 
   private:
     Clock::time_point _timestamp;

--- a/src/jaegertracing/Reference.cpp
+++ b/src/jaegertracing/Reference.cpp
@@ -15,3 +15,27 @@
  */
 
 #include "jaegertracing/Reference.h"
+#include "jaegertracing/thrift-gen/jaeger_types.h"
+
+namespace jaegertracing {
+void Reference::thrift(thrift::SpanRef& spanRef) const
+{
+    switch (_type) {
+    case Type::ChildOfRef: {
+        spanRef.__set_refType(thrift::SpanRefType::CHILD_OF);
+    } break;
+    case Type::FollowsFromRef: {
+        spanRef.__set_refType(thrift::SpanRefType::FOLLOWS_FROM);
+    } break;
+    default: {
+        std::ostringstream oss;
+        oss << "Invalid span reference type " << static_cast<int>(_type)
+            << ", context " << _spanContext;
+        throw std::invalid_argument(oss.str());
+    } break;
+    }
+    spanRef.__set_traceIdHigh(_spanContext.traceID().high());
+    spanRef.__set_traceIdLow(_spanContext.traceID().low());
+    spanRef.__set_spanId(_spanContext.spanID());
+}
+}  // namespace jaegertracing

--- a/src/jaegertracing/Reference.h
+++ b/src/jaegertracing/Reference.h
@@ -24,9 +24,11 @@
 
 #include "jaegertracing/Compilers.h"
 #include "jaegertracing/SpanContext.h"
-#include "jaegertracing/thrift-gen/jaeger_types.h"
 
 namespace jaegertracing {
+namespace thrift {
+class SpanRef;
+}
 
 class Reference {
   public:
@@ -42,28 +44,7 @@ class Reference {
 
     Type type() const { return _type; }
 
-    thrift::SpanRef thrift() const
-    {
-        thrift::SpanRef spanRef;
-        switch (_type) {
-        case Type::ChildOfRef: {
-            spanRef.__set_refType(thrift::SpanRefType::CHILD_OF);
-        } break;
-        case Type::FollowsFromRef: {
-            spanRef.__set_refType(thrift::SpanRefType::FOLLOWS_FROM);
-        } break;
-        default: {
-            std::ostringstream oss;
-            oss << "Invalid span reference type " << static_cast<int>(_type)
-                << ", context " << _spanContext;
-            throw std::invalid_argument(oss.str());
-        } break;
-        }
-        spanRef.__set_traceIdHigh(_spanContext.traceID().high());
-        spanRef.__set_traceIdLow(_spanContext.traceID().low());
-        spanRef.__set_spanId(_spanContext.spanID());
-        return spanRef;
-    }
+    void thrift(thrift::SpanRef& spanRef) const;
 
   private:
     SpanContext _spanContext;

--- a/src/jaegertracing/ReferenceTest.cpp
+++ b/src/jaegertracing/ReferenceTest.cpp
@@ -16,6 +16,7 @@
 
 #include "jaegertracing/Reference.h"
 #include "jaegertracing/SpanContext.h"
+#include "jaegertracing/thrift-gen/jaeger_types.h"
 #include <gtest/gtest.h>
 #include <stdexcept>
 
@@ -25,11 +26,14 @@ TEST(Reference, testThriftConversion)
 {
     const SpanContext context;
     const Reference childRef(context, Reference::Type::ChildOfRef);
-    ASSERT_NO_THROW(childRef.thrift());
+    thrift::SpanRef thriftChildRef;
+    ASSERT_NO_THROW(childRef.thrift(thriftChildRef));
     const Reference followsFromRef(context, Reference::Type::FollowsFromRef);
-    ASSERT_NO_THROW(followsFromRef.thrift());
+    thrift::SpanRef thriftFollowsFromRef;
+    ASSERT_NO_THROW(followsFromRef.thrift(thriftFollowsFromRef));
     const Reference invalidRef(context, static_cast<Reference::Type>(-1));
-    ASSERT_THROW(invalidRef.thrift(), std::invalid_argument);
+    thrift::SpanRef thriftInvalidRef;
+    ASSERT_THROW(invalidRef.thrift(thriftInvalidRef), std::invalid_argument);
 }
 
 }  // namespace jaegertracing

--- a/src/jaegertracing/SpanTest.cpp
+++ b/src/jaegertracing/SpanTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "jaegertracing/Span.h"
+#include "jaegertracing/thrift-gen/jaeger_types.h"
 #include <gtest/gtest.h>
 #include <string>
 
@@ -25,7 +26,8 @@ TEST(Span, testThriftConversion)
     const Span span;
     ASSERT_TRUE(span.serviceName().empty());
     ASSERT_TRUE(span.operationName().empty());
-    ASSERT_NO_THROW(span.thrift());
+    thrift::Span thriftSpan;
+    ASSERT_NO_THROW(span.thrift(thriftSpan));
 }
 
 }  // namespace jaegertracing

--- a/src/jaegertracing/Tag.cpp
+++ b/src/jaegertracing/Tag.cpp
@@ -15,3 +15,65 @@
  */
 
 #include "jaegertracing/Tag.h"
+#include "jaegertracing/thrift-gen/jaeger_types.h"
+
+namespace jaegertracing {
+class ThriftVisitor {
+  public:
+    using result_type = void;
+
+    explicit ThriftVisitor(thrift::Tag& tag)
+        : _tag(tag)
+    {
+    }
+
+    void operator()(const std::string& value) const { setString(value); }
+
+    void operator()(const char* value) const { setString(value); }
+
+    void operator()(double value) const
+    {
+        _tag.__set_vType(thrift::TagType::DOUBLE);
+        _tag.__set_vDouble(value);
+    }
+
+    void operator()(bool value) const
+    {
+        _tag.__set_vType(thrift::TagType::BOOL);
+        _tag.__set_vBool(value);
+    }
+
+    void operator()(int64_t value) const { setLong(value); }
+
+    void operator()(uint64_t value) const { setLong(value); }
+
+    template <typename Arg>
+    void operator()(Arg&& value) const
+    {
+        // No-op
+    }
+
+  private:
+    void setString(opentracing::string_view value) const
+    {
+        _tag.__set_vType(thrift::TagType::STRING);
+        _tag.__set_vStr(value);
+    }
+
+    void setLong(int64_t value) const
+    {
+        _tag.__set_vType(thrift::TagType::LONG);
+        _tag.__set_vLong(value);
+    }
+
+    thrift::Tag& _tag;
+};
+
+void Tag::thrift(thrift::Tag& tag) const
+{
+    tag.__set_key(_key);
+    ThriftVisitor visitor(tag);
+    opentracing::util::apply_visitor(visitor, _value);
+}
+
+}  // namespace jaegertracing

--- a/src/jaegertracing/TagTest.cpp
+++ b/src/jaegertracing/TagTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "jaegertracing/Tag.h"
+#include "jaegertracing/thrift-gen/jaeger_types.h"
 #include <gtest/gtest.h>
 #include <string>
 
@@ -31,7 +32,8 @@ TEST(Tag, testThriftConversion)
                          { "testCStr", "test" } };
 
     for (auto&& tag : tags) {
-        ASSERT_NO_THROW(tag.thrift());
+        thrift::Tag thriftTag;
+        ASSERT_NO_THROW(tag.thrift(thriftTag));
     }
 }
 

--- a/src/jaegertracing/UDPTransport.cpp
+++ b/src/jaegertracing/UDPTransport.cpp
@@ -28,7 +28,8 @@
 #include <thrift/transport/TBufferTransports.h>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4267) // Conversion from unsigned to signed. It should not be a problem here.
+#pragma warning(disable : 4267)  // Conversion from unsigned to signed. It
+                                 // should not be a problem here.
 #endif
 
 namespace jaegertracing {
@@ -76,7 +77,11 @@ int UDPTransport::append(const Span& span)
         std::transform(std::begin(tracerTags),
                        std::end(tracerTags),
                        std::back_inserter(thriftTags),
-                       [](const Tag& tag) { return tag.thrift(); });
+                       [](const Tag& tag) {
+                           thrift::Tag thriftTag;
+                           tag.thrift(thriftTag);
+                           return thriftTag;
+                       });
         _process.__set_tags(thriftTags);
 
         _processByteSize =
@@ -84,7 +89,8 @@ int UDPTransport::append(const Span& span)
         _maxSpanBytes =
             _client->maxPacketSize() - _processByteSize - kEmitBatchOverhead;
     }
-    const auto jaegerSpan = span.thrift();
+    thrift::Span jaegerSpan;
+    span.thrift(jaegerSpan);
     const auto spanSize =
         calcSizeOfSerializedThrift(jaegerSpan, _client->maxPacketSize());
     if (spanSize > _maxSpanBytes) {

--- a/src/jaegertracing/reporters/Config.h
+++ b/src/jaegertracing/reporters/Config.h
@@ -22,11 +22,7 @@
 #include <string>
 
 #include "jaegertracing/Logging.h"
-#include "jaegertracing/UDPTransport.h"
 #include "jaegertracing/metrics/Metrics.h"
-#include "jaegertracing/reporters/CompositeReporter.h"
-#include "jaegertracing/reporters/LoggingReporter.h"
-#include "jaegertracing/reporters/RemoteReporter.h"
 #include "jaegertracing/reporters/Reporter.h"
 #include "jaegertracing/utils/YAML.h"
 
@@ -87,24 +83,7 @@ class Config {
 
     std::unique_ptr<Reporter> makeReporter(const std::string& serviceName,
                                            logging::Logger& logger,
-                                           metrics::Metrics& metrics) const
-    {
-        std::unique_ptr<UDPTransport> sender(
-            new UDPTransport(net::IPAddress::v4(_localAgentHostPort), 0));
-        std::unique_ptr<RemoteReporter> remoteReporter(
-            new RemoteReporter(_bufferFlushInterval,
-                               _queueSize,
-                               std::move(sender),
-                               logger,
-                               metrics));
-        if (_logSpans) {
-            logger.info("Initializing logging reporter");
-            return std::unique_ptr<CompositeReporter>(new CompositeReporter(
-                { std::shared_ptr<RemoteReporter>(std::move(remoteReporter)),
-                  std::make_shared<LoggingReporter>(logger) }));
-        }
-        return std::unique_ptr<Reporter>(std::move(remoteReporter));
-    }
+                                           metrics::Metrics& metrics) const;
 
     int queueSize() const { return _queueSize; }
 

--- a/src/jaegertracing/samplers/AdaptiveSampler.cpp
+++ b/src/jaegertracing/samplers/AdaptiveSampler.cpp
@@ -16,6 +16,7 @@
 
 #include "jaegertracing/samplers/AdaptiveSampler.h"
 #include "jaegertracing/samplers/GuaranteedThroughputProbabilisticSampler.h"
+#include "jaegertracing/thrift-gen/sampling_types.h"
 #include <cassert>
 #include <iterator>
 #include <memory>

--- a/src/jaegertracing/samplers/AdaptiveSampler.h
+++ b/src/jaegertracing/samplers/AdaptiveSampler.h
@@ -27,9 +27,14 @@
 #include "jaegertracing/samplers/GuaranteedThroughputProbabilisticSampler.h"
 #include "jaegertracing/samplers/ProbabilisticSampler.h"
 #include "jaegertracing/samplers/Sampler.h"
-#include "jaegertracing/thrift-gen/sampling_types.h"
 
 namespace jaegertracing {
+namespace sampling_manager {
+namespace thrift {
+class PerOperationSamplingStrategies;
+}
+}  // namespace sampling_manager
+
 namespace samplers {
 
 class AdaptiveSampler : public Sampler {

--- a/src/jaegertracing/samplers/RemotelyControlledSampler.cpp
+++ b/src/jaegertracing/samplers/RemotelyControlledSampler.cpp
@@ -27,6 +27,7 @@
 #include "jaegertracing/net/http/Response.h"
 #include "jaegertracing/samplers/AdaptiveSampler.h"
 #include "jaegertracing/samplers/RemoteSamplingJSON.h"
+#include "jaegertracing/thrift-gen/SamplingManager.h"
 #include "jaegertracing/utils/ErrorUtil.h"
 
 namespace jaegertracing {

--- a/src/jaegertracing/samplers/RemotelyControlledSampler.h
+++ b/src/jaegertracing/samplers/RemotelyControlledSampler.h
@@ -29,9 +29,17 @@
 #include "jaegertracing/metrics/Metrics.h"
 #include "jaegertracing/samplers/ProbabilisticSampler.h"
 #include "jaegertracing/samplers/Sampler.h"
-#include "jaegertracing/thrift-gen/SamplingManager.h"
 
 namespace jaegertracing {
+
+namespace sampling_manager {
+namespace thrift {
+class PerOperationSamplingStrategies;
+class SamplingStrategyResponse;
+class SamplingManagerIf;
+}  // namespace thrift
+}  // namespace sampling_manager
+
 namespace samplers {
 
 class RemotelyControlledSampler : public Sampler {

--- a/src/jaegertracing/samplers/SamplerTest.cpp
+++ b/src/jaegertracing/samplers/SamplerTest.cpp
@@ -20,8 +20,8 @@
 
 #include "jaegertracing/Constants.h"
 #include "jaegertracing/Tag.h"
-#include "jaegertracing/samplers/Config.h"
 #include "jaegertracing/samplers/AdaptiveSampler.h"
+#include "jaegertracing/samplers/Config.h"
 #include "jaegertracing/samplers/ConstSampler.h"
 #include "jaegertracing/samplers/GuaranteedThroughputProbabilisticSampler.h"
 #include "jaegertracing/samplers/ProbabilisticSampler.h"
@@ -31,6 +31,7 @@
 #include "jaegertracing/samplers/SamplingStatus.h"
 #include "jaegertracing/testutils/MockAgent.h"
 #include "jaegertracing/testutils/TUDPTransport.h"
+#include "jaegertracing/thrift-gen/jaeger_types.h"
 
 namespace jaegertracing {
 namespace samplers {
@@ -39,8 +40,7 @@ namespace {
 constexpr auto kTestOperationName = "op";
 constexpr auto kTestFirstTimeOperationName = "firstTimeOp";
 constexpr auto kTestDefaultSamplingProbability = 0.5;
-constexpr auto kTestMaxID =
-    std::numeric_limits<uint64_t>::max() / 2 + 1;
+constexpr auto kTestMaxID = std::numeric_limits<uint64_t>::max() / 2 + 1;
 constexpr auto kTestDefaultMaxOperations = 10;
 
 const Tag testProbablisticExpectedTags[] = {
@@ -54,7 +54,11 @@ const Tag testLowerBoundExpectedTags[] = { { "sampler.type", "lowerbound" },
     {                                                                          \
         ASSERT_EQ(sizeof(tagArr) / sizeof(Tag), (tagVec).size());              \
         for (auto i = static_cast<size_t>(0); i < (tagVec).size(); ++i) {      \
-            ASSERT_EQ((tagArr)[i].thrift(), (tagVec)[i].thrift());             \
+            jaegertracing::thrift::Tag thriftTagArr;                           \
+            jaegertracing::thrift::Tag thriftTagVec;                           \
+            (tagArr)[i].thrift(thriftTagArr);                                  \
+            (tagVec)[i].thrift(thriftTagVec);                                  \
+            ASSERT_EQ(thriftTagArr, thriftTagVec);                             \
         }                                                                      \
     }
 


### PR DESCRIPTION
- Adresses https://github.com/jaegertracing/jaeger-client-cpp/issues/121
so that thrift is a private dependency of jaeger.

- Moved the minimal set of code from .h to .cpp to avoid thrift-gen headers to be exposed as part of the API.

Signed-off-by: Benoit De Backer <bdebacker@murex.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->
