### PR TITLE
Make compile options private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ function(add_lib_deps lib)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)
   target_link_libraries(${lib} PUBLIC ${link_flags} ${LIBS})
-  target_compile_options(${lib} PUBLIC ${cxx_flags})
+  target_compile_options(${lib} PRIVATE ${cxx_flags})
 endfunction()
 
 function(update_path_for_test atest)


### PR DESCRIPTION
##  Which problem is this PR solving?
The CMake configuration pollutes the compiler options of projects that include the Jaeger headers. This results in the same warning options that are enabled for this project to leak into other projects, causing problems when integrating Jaeger with codebases that cannot be cleanly compiled using the same options.

## Short description of the changes

Since the changes introduced by 7e9a135b362c47f7e4d42e0693b05b91a70e6888 the Jaeger internal compiler options are propagated to projects that depend on the Jaeger headers.

Since these options are not strictly necessary to build Jaeger and are only added to make sure that warnings are emitted for this project, they could instead be made private. This avoids polluting other projects with the internal Jaeger compiler options.