### PR TITLE
Support Tracer tags and  configuration via environment variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ set(SRC
     src/jaegertracing/thrift-gen/zipkincore_types.cpp
     src/jaegertracing/utils/ErrorUtil.cpp
     src/jaegertracing/utils/HexParsing.cpp
+    src/jaegertracing/utils/EnvVariable.cpp
     src/jaegertracing/utils/RateLimiter.cpp
     src/jaegertracing/utils/UDPTransporter.cpp
     src/jaegertracing/utils/HTTPTransporter.cpp

--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ sampler:
   samplingServerURL: http://jaeger-agent.local:5778
 ```
 
+### Configuration via Environment
+
+It's possible to populate the tracer configuration from the environement variables by calling `jaegertracing::Config::fromEnv`.
+
+The following property names are currently available:
+
+Property | Description
+--- | ---
+JAEGER_SERVICE_NAME | The service name
+JAEGER_DISABLED _(not recommended)_ | Instructs the Configuration to return a no-op tracer
+JAEGER_AGENT_HOST | The hostname for communicating with agent via UDP
+JAEGER_AGENT_PORT | The port for communicating with agent via UDP
+JAEGER_ENDPOINT | The traces endpoint, in case the client should connect directly to the Collector, like http://jaeger-collector:14268/api/traces
+JAEGER_REPORTER_LOG_SPANS | Whether the reporter should also log the spans
+JAEGER_REPORTER_MAX_QUEUE_SIZE | The reporter's maximum queue size
+JAEGER_REPORTER_FLUSH_INTERVAL | The reporter's flush interval (ms)
+JAEGER_SAMPLER_TYPE | The [sampler type](https://www.jaegertracing.io/docs/latest/sampling/#client-sampling-configuration)
+JAEGER_SAMPLER_PARAM | The sampler parameter (number)
+JAEGER_SAMPLER_MANAGER_HOST_PORT | The host name and port when using the remote controlled sampler
+JAEGER_TAGS | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
+
 ## License
 
 [Apache 2.0 License](./LICENSE).

--- a/src/jaegertracing/Config.h
+++ b/src/jaegertracing/Config.h
@@ -71,7 +71,7 @@ class Config {
                     const baggage::RestrictionsConfig& baggageRestrictions =
                         baggage::RestrictionsConfig(),
                     const std::string& serviceName = "",
-                    const std::vector<Tag> tags = std::vector<Tag>())
+                    const std::vector<Tag>&  tags = std::vector<Tag>())
         : _disabled(disabled)
         , _serviceName(serviceName)
         , _tags(tags)

--- a/src/jaegertracing/Config.h
+++ b/src/jaegertracing/Config.h
@@ -19,6 +19,7 @@
 
 #include "jaegertracing/Compilers.h"
 #include "jaegertracing/Constants.h"
+#include "jaegertracing/Tag.h"
 #include "jaegertracing/baggage/RestrictionsConfig.h"
 #include "jaegertracing/propagation/HeadersConfig.h"
 #include "jaegertracing/reporters/Config.h"
@@ -29,6 +30,11 @@ namespace jaegertracing {
 
 class Config {
   public:
+
+    static constexpr auto kJAEGER_SERVICE_NAME_ENV_PROP = "JAEGER_SERVICE_NAME";
+    static constexpr auto kJAEGER_TAGS_ENV_PROP = "JAEGER_TAGS";
+    static constexpr auto kJAEGER_JAEGER_DISABLED_ENV_PROP = "JAEGER_DISABLED";
+
 #ifdef JAEGERTRACING_WITH_YAML_CPP
 
     static Config parse(const YAML::Node& configYAML)
@@ -36,6 +42,9 @@ class Config {
         if (!configYAML.IsDefined() || !configYAML.IsMap()) {
             return Config();
         }
+
+        const auto serviceName =
+            utils::yaml::findOrDefault<std::string>(configYAML, "service_name", "");
 
         const auto disabled =
             utils::yaml::findOrDefault<bool>(configYAML, "disabled", false);
@@ -49,7 +58,7 @@ class Config {
         const auto baggageRestrictions =
             baggage::RestrictionsConfig::parse(baggageRestrictionsNode);
         return Config(
-            disabled, sampler, reporter, headers, baggageRestrictions);
+            disabled, sampler, reporter, headers, baggageRestrictions, serviceName);
     }
 
 #endif  // JAEGERTRACING_WITH_YAML_CPP
@@ -60,8 +69,12 @@ class Config {
                     const propagation::HeadersConfig& headers =
                         propagation::HeadersConfig(),
                     const baggage::RestrictionsConfig& baggageRestrictions =
-                        baggage::RestrictionsConfig())
+                        baggage::RestrictionsConfig(),
+                    const std::string& serviceName = "",
+                    const std::vector<Tag> tags = std::vector<Tag>())
         : _disabled(disabled)
+        , _serviceName(serviceName)
+        , _tags(tags)
         , _sampler(sampler)
         , _reporter(reporter)
         , _headers(headers)
@@ -82,8 +95,16 @@ class Config {
         return _baggageRestrictions;
     }
 
+    const std::string& serviceName() const { return _serviceName; }
+
+    const std::vector<Tag>& tags() const { return _tags; }
+
+    void fromEnv();
+
   private:
     bool _disabled;
+    std::string _serviceName;
+    std::vector< Tag > _tags;
     samplers::Config _sampler;
     reporters::Config _reporter;
     propagation::HeadersConfig _headers;

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -126,19 +126,6 @@ TEST(Config, testFromEnv)
                   "test-service",
                   tags);
 
-    ASSERT_EQ(std::string("http://host36:56568"), config.reporter().endpoint());
-    ASSERT_EQ(std::string("host35:77"), config.reporter().localAgentHostPort());
-
-    ASSERT_EQ(10, config.reporter().queueSize());
-    ASSERT_EQ(std::chrono::milliseconds(100),
-              config.reporter().bufferFlushInterval());
-    ASSERT_EQ(false, config.reporter().logSpans());
-
-    ASSERT_EQ(.7, config.sampler().param());
-    ASSERT_EQ(std::string("probabilistic"), config.sampler().type());
-    ASSERT_EQ(std::string("http://host34:57/sampling"),
-              config.sampler().samplingServerURL());
-
     config.fromEnv();
 
     ASSERT_EQ(std::string("http://host36:56568"), config.reporter().endpoint());
@@ -151,8 +138,6 @@ TEST(Config, testFromEnv)
 
     ASSERT_EQ(.7, config.sampler().param());
     ASSERT_EQ(std::string("probabilistic"), config.sampler().type());
-    ASSERT_EQ(std::string("http://host34:57/sampling"),
-              config.sampler().samplingServerURL());
 
     setEnv("JAEGER_AGENT_HOST", "host33");
     setEnv("JAEGER_AGENT_PORT", "45");
@@ -164,7 +149,6 @@ TEST(Config, testFromEnv)
 
     setEnv("JAEGER_SAMPLER_PARAM", "33");
     setEnv("JAEGER_SAMPLER_TYPE", "const");
-    setEnv("JAEGER_SAMPLER_MANAGER_HOST_PORT", "host34:56");
 
     setEnv("JAEGER_SERVICE_NAME", "AService");
     setEnv("JAEGER_TAGS", "hostname=foobar,my.app.version=4.5.6");
@@ -181,8 +165,6 @@ TEST(Config, testFromEnv)
 
     ASSERT_EQ(33., config.sampler().param());
     ASSERT_EQ(std::string("const"), config.sampler().type());
-    ASSERT_EQ(std::string("http://host34:56/sampling"),
-              config.sampler().samplingServerURL());
 
     ASSERT_EQ(std::string("AService"), config.serviceName());
 
@@ -195,7 +177,7 @@ TEST(Config, testFromEnv)
 
     ASSERT_EQ(false, config.disabled());
 
-    setEnv("JAEGER_DISABLED", "TRue");
+    setEnv("JAEGER_DISABLED", "TRue");  // case-insensitive
     setEnv("JAEGER_AGENT_PORT", "445");
 
     config.fromEnv();

--- a/src/jaegertracing/Tracer.cpp
+++ b/src/jaegertracing/Tracer.cpp
@@ -239,6 +239,7 @@ Tracer::make(const std::string& serviceName,
                                               logger,
                                               metrics,
                                               config.headers(),
+                                              config.tags(),
                                               options));
 }
 

--- a/src/jaegertracing/Tracer.h
+++ b/src/jaegertracing/Tracer.h
@@ -76,14 +76,6 @@ class Tracer : public opentracing::Tracer,
         metrics::NullStatsFactory factory;
         return make(serviceName, config, logger, factory);
     }
-
-    static std::shared_ptr<opentracing::Tracer>
-    make(const Config& config, const std::shared_ptr<logging::Logger>& logger)
-    {
-        metrics::NullStatsFactory factory;
-        return make(config.serviceName(), config, logger, factory);
-    }
-
     static std::shared_ptr<opentracing::Tracer>
     make(const std::string& serviceName,
          const Config& config,
@@ -92,31 +84,12 @@ class Tracer : public opentracing::Tracer,
     {
         return make(serviceName, config, logger, statsFactory, 0);
     }
-
-    static std::shared_ptr<opentracing::Tracer>
-    make(const Config& config,
-         const std::shared_ptr<logging::Logger>& logger,
-         metrics::StatsFactory& statsFactory)
-    {
-        return make(config.serviceName(), config, logger, statsFactory, 0);
-    }
-
     static std::shared_ptr<opentracing::Tracer>
     make(const std::string& serviceName,
          const Config& config,
          const std::shared_ptr<logging::Logger>& logger,
          metrics::StatsFactory& statsFactory,
          int options);
-
-    static std::shared_ptr<opentracing::Tracer>
-    make(const Config& config,
-         const std::shared_ptr<logging::Logger>& logger,
-         metrics::StatsFactory& statsFactory,
-         int options)
-    {
-        return make(
-            config.serviceName(), config, logger, statsFactory, options);
-    }
 
     ~Tracer() { Close(); }
 

--- a/src/jaegertracing/Tracer.h
+++ b/src/jaegertracing/Tracer.h
@@ -53,6 +53,13 @@ class Tracer : public opentracing::Tracer,
 
     static constexpr auto kGen128BitOption = 1;
 
+    static std::shared_ptr<opentracing::Tracer> make(const Config& config)
+    {
+        return make(config.serviceName(),
+                    config,
+                    std::shared_ptr<logging::Logger>(logging::nullLogger()));
+    }
+
     static std::shared_ptr<opentracing::Tracer>
     make(const std::string& serviceName, const Config& config)
     {
@@ -71,6 +78,13 @@ class Tracer : public opentracing::Tracer,
     }
 
     static std::shared_ptr<opentracing::Tracer>
+    make(const Config& config, const std::shared_ptr<logging::Logger>& logger)
+    {
+        metrics::NullStatsFactory factory;
+        return make(config.serviceName(), config, logger, factory);
+    }
+
+    static std::shared_ptr<opentracing::Tracer>
     make(const std::string& serviceName,
          const Config& config,
          const std::shared_ptr<logging::Logger>& logger,
@@ -80,11 +94,29 @@ class Tracer : public opentracing::Tracer,
     }
 
     static std::shared_ptr<opentracing::Tracer>
+    make(const Config& config,
+         const std::shared_ptr<logging::Logger>& logger,
+         metrics::StatsFactory& statsFactory)
+    {
+        return make(config.serviceName(), config, logger, statsFactory, 0);
+    }
+
+    static std::shared_ptr<opentracing::Tracer>
     make(const std::string& serviceName,
          const Config& config,
          const std::shared_ptr<logging::Logger>& logger,
          metrics::StatsFactory& statsFactory,
          int options);
+
+    static std::shared_ptr<opentracing::Tracer>
+    make(const Config& config,
+         const std::shared_ptr<logging::Logger>& logger,
+         metrics::StatsFactory& statsFactory,
+         int options)
+    {
+        return make(
+            config.serviceName(), config, logger, statsFactory, options);
+    }
 
     ~Tracer() { Close(); }
 
@@ -202,6 +234,7 @@ class Tracer : public opentracing::Tracer,
            const std::shared_ptr<logging::Logger>& logger,
            const std::shared_ptr<metrics::Metrics>& metrics,
            const propagation::HeadersConfig& headersConfig,
+           const std::vector<Tag>& tags,
            int options)
         : _serviceName(serviceName)
         , _hostIPv4(net::IPAddress::localIP(AF_INET))
@@ -232,6 +265,8 @@ class Tracer : public opentracing::Tracer,
         else {
             _tags.push_back(Tag(kTracerIPTagKey, _hostIPv4.host()));
         }
+
+        std::copy(tags.cbegin(), tags.cend(), std::back_inserter(_tags));
 
         std::random_device device;
         _randomNumberGenerator.seed(device());

--- a/src/jaegertracing/TracerFactory.cpp
+++ b/src/jaegertracing/TracerFactory.cpp
@@ -49,10 +49,9 @@ TracerFactory::MakeTracer(const char* configuration,
         return opentracing::make_unexpected(
             opentracing::invalid_configuration_error);
     }
-    std::string serviceName = serviceNameNode.Scalar();
 
     const auto tracerConfig = jaegertracing::Config::parse(yaml);
-    return jaegertracing::Tracer::make(serviceName, tracerConfig);
+    return jaegertracing::Tracer::make(tracerConfig);
 #endif  // JAEGERTRACING_WITH_YAML_CPP
 } catch (const std::bad_alloc&) {
     return opentracing::make_unexpected(

--- a/src/jaegertracing/TracerTest.cpp
+++ b/src/jaegertracing/TracerTest.cpp
@@ -416,4 +416,36 @@ TEST(Tracer, testPropagation)
     tracer->Close();
 }
 
+TEST(Tracer, testTracerTags)
+{
+    std::vector<Tag> tags;
+    tags.emplace_back("hostname", std::string("foobar"));
+    tags.emplace_back("my.app.version", std::string("1.2.3"));
+
+    Config config(
+        false,
+        samplers::Config(
+            "const", 1, "", 0, samplers::Config::Clock::duration()),
+        reporters::Config(0, std::chrono::milliseconds(100), false, "", ""),
+        propagation::HeadersConfig(),
+        baggage::RestrictionsConfig(),
+        "test-service",
+        tags);
+
+    auto tracer = Tracer::make(config, logging::nullLogger());
+    const auto jaegerTracer = std::static_pointer_cast<Tracer>(tracer);
+
+    ASSERT_TRUE(std::find(jaegerTracer->tags().begin(),
+                          jaegerTracer->tags().end(),
+                          Tag("hostname", std::string("foobar"))) !=
+        jaegerTracer->tags().end());
+
+    ASSERT_TRUE(std::find(jaegerTracer->tags().begin(),
+                          jaegerTracer->tags().end(),
+                          Tag("my.app.version", std::string("1.2.3"))) !=
+        jaegerTracer->tags().end());
+
+    ASSERT_EQ(std::string("test-service"), jaegerTracer->serviceName());
+}
+
 }  // namespace jaegertracing

--- a/src/jaegertracing/TracerTest.cpp
+++ b/src/jaegertracing/TracerTest.cpp
@@ -432,7 +432,7 @@ TEST(Tracer, testTracerTags)
         "test-service",
         tags);
 
-    auto tracer = Tracer::make(config, logging::nullLogger());
+    auto tracer = Tracer::make(config);
     const auto jaegerTracer = std::static_pointer_cast<Tracer>(tracer);
 
     ASSERT_TRUE(std::find(jaegerTracer->tags().begin(),

--- a/src/jaegertracing/net/IPAddress.h
+++ b/src/jaegertracing/net/IPAddress.h
@@ -53,7 +53,7 @@ namespace net {
 
 class IPAddress {
   public:
-    static IPAddress v4(const std::string& hostPort)
+    static std::pair<std::string, int> parse(const std::string& hostPort)
     {
         const auto colonPos = hostPort.find(':');
         const auto ip = hostPort.substr(0, colonPos);
@@ -65,7 +65,13 @@ class IPAddress {
                 port = 0;
             }
         }
-        return v4(ip, port);
+        return std::make_pair(ip, port);
+    }
+
+    static IPAddress v4(const std::string& hostPort)
+    {
+        auto result = parse(hostPort);
+        return v4(result.first, result.second);
     }
 
     static IPAddress v4(const std::string& ip, int port)

--- a/src/jaegertracing/reporters/Config.h
+++ b/src/jaegertracing/reporters/Config.h
@@ -40,6 +40,16 @@ class Config {
     static constexpr auto kDefaultLocalAgentHostPort = "127.0.0.1:6831";
     static constexpr auto kDefaultEndpoint = "";
 
+    static constexpr auto kJAEGER_AGENT_HOST_ENV_PROP = "JAEGER_AGENT_HOST";
+    static constexpr auto kJAEGER_AGENT_PORT_ENV_PROP = "JAEGER_AGENT_PORT";
+    static constexpr auto kJAEGER_ENDPOINT_ENV_PROP = "JAEGER_ENDPOINT";
+
+    static constexpr auto kJAEGER_REPORTER_LOG_SPANS_ENV_PROP = "JAEGER_REPORTER_LOG_SPANS";
+    static constexpr auto kJAEGER_REPORTER_FLUSH_INTERVAL_ENV_PROP = "JAEGER_REPORTER_FLUSH_INTERVAL";
+    static constexpr auto kJAEGER_REPORTER_MAX_QUEUE_SIZE_ENV_PROP = "JAEGER_REPORTER_MAX_QUEUE_SIZE";
+
+
+
     static Clock::duration defaultBufferFlushInterval()
     {
         return std::chrono::seconds(10);
@@ -110,6 +120,8 @@ class Config {
     {
       return _endpoint;
     }
+
+    void fromEnv();
 
   private:
     int _queueSize;

--- a/src/jaegertracing/samplers/Config.cpp
+++ b/src/jaegertracing/samplers/Config.cpp
@@ -15,12 +15,39 @@
  */
 
 #include "jaegertracing/samplers/Config.h"
+#include "jaegertracing/utils/EnvVariable.h"
 
 namespace jaegertracing {
 namespace samplers {
 
 constexpr double Config::kDefaultSamplingProbability;
 constexpr const char* Config::kDefaultSamplingServerURL;
+
+constexpr const char* Config::kJAEGER_SAMPLER_TYPE_ENV_PROP;
+constexpr const char* Config::kJAEGER_SAMPLER_PARAM_ENV_PROP;
+constexpr const char* Config::kJAEGER_SAMPLER_MANAGER_HOST_PORT_ENV_PROP;
+
+void Config::fromEnv()
+{
+    const auto samplerType = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_TYPE_ENV_PROP);
+    if (!samplerType.empty()) {
+        _type = samplerType;
+    }
+
+    const auto param = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_PARAM_ENV_PROP);
+    if (!param.empty()) {
+        std::istringstream iss(param);
+        int paramVal = 0;
+        if (iss >> paramVal) {
+            _param = paramVal;
+        }
+    }
+
+    const auto samplerUrl = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_MANAGER_HOST_PORT_ENV_PROP);
+    if (!samplerUrl.empty()) {
+        _samplingServerURL = "http://" + samplerUrl + "/sampling";
+    }
+}
 
 }  // namespace samplers
 }  // namespace jaegertracing

--- a/src/jaegertracing/samplers/Config.cpp
+++ b/src/jaegertracing/samplers/Config.cpp
@@ -25,7 +25,6 @@ constexpr const char* Config::kDefaultSamplingServerURL;
 
 constexpr const char* Config::kJAEGER_SAMPLER_TYPE_ENV_PROP;
 constexpr const char* Config::kJAEGER_SAMPLER_PARAM_ENV_PROP;
-constexpr const char* Config::kJAEGER_SAMPLER_MANAGER_HOST_PORT_ENV_PROP;
 
 void Config::fromEnv()
 {
@@ -41,11 +40,6 @@ void Config::fromEnv()
         if (iss >> paramVal) {
             _param = paramVal;
         }
-    }
-
-    const auto samplerUrl = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_MANAGER_HOST_PORT_ENV_PROP);
-    if (!samplerUrl.empty()) {
-        _samplingServerURL = "http://" + samplerUrl + "/sampling";
     }
 }
 

--- a/src/jaegertracing/samplers/Config.h
+++ b/src/jaegertracing/samplers/Config.h
@@ -45,6 +45,10 @@ class Config {
     static constexpr auto kDefaultSamplingServerURL = "http://127.0.0.1:5778/sampling";
     static constexpr auto kDefaultMaxOperations = 2000;
 
+    static constexpr auto kJAEGER_SAMPLER_TYPE_ENV_PROP = "JAEGER_SAMPLER_TYPE";
+    static constexpr auto kJAEGER_SAMPLER_PARAM_ENV_PROP = "JAEGER_SAMPLER_PARAM";
+    static constexpr auto kJAEGER_SAMPLER_MANAGER_HOST_PORT_ENV_PROP = "JAEGER_SAMPLER_MANAGER_HOST_PORT";
+
     static Clock::duration defaultSamplingRefreshInterval()
     {
         return std::chrono::minutes(1);
@@ -169,6 +173,8 @@ class Config {
     {
         return _samplingRefreshInterval;
     }
+
+  void fromEnv();
 
   private:
     std::string _type;

--- a/src/jaegertracing/utils/EnvVariable.cpp
+++ b/src/jaegertracing/utils/EnvVariable.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jaegertracing/utils/EnvVariable.h"

--- a/src/jaegertracing/utils/EnvVariable.h
+++ b/src/jaegertracing/utils/EnvVariable.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JAEGERTRACING_UTILS_ENV_VARIABLE_H
+#define JAEGERTRACING_UTILS_ENV_VARIABLE_H
+
+#include <string>
+#include <sstream>
+#include <algorithm>
+
+namespace jaegertracing {
+namespace utils {
+namespace EnvVariable {
+
+inline std::string getStringVariable(const char* envVar)
+{
+    const auto rawVariable = std::getenv(envVar);
+    return std::string(rawVariable ? rawVariable : "");
+}
+
+inline std::pair<bool, int> getIntVariable(const char* envVar)
+{
+    const auto rawVariable = std::getenv(envVar);
+    const std::string variable(rawVariable ? rawVariable : "");
+    if (!variable.empty()) {
+        std::istringstream iss(variable);
+        int intVal = 0;
+        if (iss >> intVal) {
+            return std::make_pair(false, intVal);
+        }
+    }
+    return std::make_pair(false, 0);
+}
+
+inline std::pair<bool, bool> getBoolVariable(const char* envVar)
+{
+    const auto rawVariable = std::getenv(envVar);
+    std::string variable(rawVariable ? rawVariable : "");
+
+    if (!variable.empty()) {
+        std::transform(
+            variable.begin(), variable.end(), variable.begin(), ::tolower);
+        return std::make_pair(true, (variable == "true"));
+    }
+    return std::make_pair(false, false);
+}
+
+}  // namespace EnvVariable
+}  // namespace utils
+}  // namespace jaegertracing
+
+#endif  // JAEGERTRACING_UTILS_HEXPARSING_H

--- a/src/jaegertracing/utils/EnvVariable.h
+++ b/src/jaegertracing/utils/EnvVariable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 The Jaeger Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: FR-MUREX-COM\mchaikhadouaihy <mehrez.douaihy@gmail.com>

## Which problem is this PR solving?
- Ability to fill a Tracer configuration from the environment variables
- Resolves #178

## Short description of the changes
- Add fromEnv method to the Tracer Config class. The method will overwrite the configuration if the corresponding environment variable is set.

Supported properties
- Tracer
  - JAEGER_SERVICE_NAME
  - JAEGER_TAGS
  - JAEGER_DISABLED
- Reporter
  - JAEGER_AGENT_HOST
  - JAEGER_AGENT_PORT
  - JAEGER_ENDPOINT
  - JAEGER_REPORTER_LOG_SPANS
  - JAEGER_REPORTER_FLUSH_INTERVAL
  - JAEGER_REPORTER_MAX_QUEUE_SIZE
- Sampler
  - JAEGER_SAMPLER_TYPE
  - JAEGER_SAMPLER_PARAM
  - JAEGER_SAMPLER_MANAGER_HOST_PORT
