### PR TITLE
Add jaeger-debug-id as a tag

### DIFF
--- a/src/jaegertracing/Tracer.cpp
+++ b/src/jaegertracing/Tracer.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "jaegertracing/Tag.h"
 #include "jaegertracing/Tracer.h"
 #include "jaegertracing/Reference.h"
 #include "jaegertracing/TraceID.h"
@@ -85,6 +86,7 @@ Tracer::StartSpanWithOptions(string_view operationName,
                 flags |=
                     (static_cast<unsigned char>(SpanContext::Flag::kSampled) |
                      static_cast<unsigned char>(SpanContext::Flag::kDebug));
+                samplerTags.push_back(Tag(kJaegerDebugHeader, parent->debugID()));
             }
             else {
                 const auto samplingStatus =


### PR DESCRIPTION
## Which problem is this PR solving?

resolves #136 

## Short description of the changes

If the trace was started with a debugID, adding jaeger-debug-id
as tag ensures that the trace will be sampled in the "debug" mode.

Additionally, the root span will have this ID as a searchable tag.


