### PR TITLE
fix configuration from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ JAEGER_REPORTER_LOG_SPANS | Whether the reporter should also log the spans
 JAEGER_REPORTER_MAX_QUEUE_SIZE | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | The reporter's flush interval (ms)
 JAEGER_SAMPLER_TYPE | The [sampler type](https://www.jaegertracing.io/docs/latest/sampling/#client-sampling-configuration)
-JAEGER_SAMPLER_PARAM | The sampler parameter (number)
-JAEGER_SAMPLER_MANAGER_HOST_PORT | The host name and port when using the remote controlled sampler
+JAEGER_SAMPLER_PARAM | The sampler parameter (double)
+JAEGER_SAMPLER_SERVER_URL | The url for the remote conf when using sampler type remote. Default is http://127.0.0.1:5778/sampling
 JAEGER_TAGS | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
 
 ## License

--- a/src/jaegertracing/samplers/Config.cpp
+++ b/src/jaegertracing/samplers/Config.cpp
@@ -36,10 +36,14 @@ void Config::fromEnv()
     const auto param = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_PARAM_ENV_PROP);
     if (!param.empty()) {
         std::istringstream iss(param);
-        int paramVal = 0;
+        double paramVal = 0;
         if (iss >> paramVal) {
             _param = paramVal;
         }
+    }
+    const auto samplingServerURL = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_SERVER_URL_ENV_PROP);
+    if (!samplingServerURL.empty()) {
+        _samplingServerURL = samplingServerURL;
     }
 }
 

--- a/src/jaegertracing/samplers/Config.h
+++ b/src/jaegertracing/samplers/Config.h
@@ -47,7 +47,7 @@ class Config {
 
     static constexpr auto kJAEGER_SAMPLER_TYPE_ENV_PROP = "JAEGER_SAMPLER_TYPE";
     static constexpr auto kJAEGER_SAMPLER_PARAM_ENV_PROP = "JAEGER_SAMPLER_PARAM";
-    static constexpr auto kJAEGER_SAMPLER_MANAGER_HOST_PORT_ENV_PROP = "JAEGER_SAMPLER_MANAGER_HOST_PORT";
+    static constexpr auto kJAEGER_SAMPLER_SERVER_URL_ENV_PROP = "JAEGER_SAMPLER_SERVER_URL";
 
     static Clock::duration defaultSamplingRefreshInterval()
     {


### PR DESCRIPTION
fix conversion to double of JAEGER_SAMPLER_PARAM
rename env var JAEGER_SAMPLER_MANAGER_HOST_PORT to JAEGER_SAMPLER_SERVER_URL
properly load JAEGER_SAMPLER_SERVER_URL

Signed-off-by: Emmanuel Courreges <emmanuel.courreges@orange.com>

This functionnality had no unit tests so I didn't add any :-)