### PR TITLE
Fix loading of sampling endpoint address from JAEGER_SAMPLING_ENDPOINT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ JAEGER_REPORTER_LOG_SPANS | Whether the reporter should also log the spans
 JAEGER_REPORTER_MAX_QUEUE_SIZE | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | The reporter's flush interval (ms)
 JAEGER_SAMPLER_TYPE | The [sampler type](https://www.jaegertracing.io/docs/latest/sampling/#client-sampling-configuration)
-JAEGER_SAMPLER_PARAM | The sampler parameter (number)
-JAEGER_SAMPLER_MANAGER_HOST_PORT | The host name and port when using the remote controlled sampler
+JAEGER_SAMPLER_PARAM | The sampler parameter (double)
+JAEGER_SAMPLER_SERVER_URL | The url for the remote conf when using sampler type remote. Default is http://127.0.0.1:5778/sampling
 JAEGER_TAGS | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
 
 ## License

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ JAEGER_REPORTER_MAX_QUEUE_SIZE | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | The reporter's flush interval (ms)
 JAEGER_SAMPLER_TYPE | The [sampler type](https://www.jaegertracing.io/docs/latest/sampling/#client-sampling-configuration)
 JAEGER_SAMPLER_PARAM | The sampler parameter (double)
-JAEGER_SAMPLER_SERVER_URL | The url for the remote conf when using sampler type remote. Default is http://127.0.0.1:5778/sampling
+JAEGER_SAMPLING_ENDPOINT | The url for the remote sampling conf when using sampler type remote. Default is http://127.0.0.1:5778/sampling
 JAEGER_TAGS | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
 
 ## License

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The default sampling collector URL is `http://127.0.0.1:5778/sampling`. Similar 
 
 ```yml
 sampler:
-  samplingServerURL: http://jaeger-agent.local:5778
+  samplingServerURL: http://jaeger-agent.local:5778/sampling
 ```
 
 ### Configuration via Environment

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -147,8 +147,9 @@ TEST(Config, testFromEnv)
     setEnv("JAEGER_REPORTER_FLUSH_INTERVAL", "45");
     setEnv("JAEGER_REPORTER_LOG_SPANS", "true");
 
-    setEnv("JAEGER_SAMPLER_PARAM", "33");
-    setEnv("JAEGER_SAMPLER_TYPE", "const");
+    setEnv("JAEGER_SAMPLER_TYPE", "remote");
+    setEnv("JAEGER_SAMPLER_PARAM", "0.33");
+    setEnv("JAEGER_SAMPLER_SERVER_URL", "http://myagent:1234");
 
     setEnv("JAEGER_SERVICE_NAME", "AService");
     setEnv("JAEGER_TAGS", "hostname=foobar,my.app.version=4.5.6");
@@ -163,8 +164,9 @@ TEST(Config, testFromEnv)
               config.reporter().bufferFlushInterval());
     ASSERT_EQ(true, config.reporter().logSpans());
 
-    ASSERT_EQ(33., config.sampler().param());
-    ASSERT_EQ(std::string("const"), config.sampler().type());
+    ASSERT_EQ(std::string("remote"), config.sampler().type());
+    ASSERT_EQ(0.33, config.sampler().param());
+    ASSERT_EQ(std::string("http://myagent:1234"), config.sampler().samplingServerURL());
 
     ASSERT_EQ(std::string("AService"), config.serviceName());
 

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -149,7 +149,7 @@ TEST(Config, testFromEnv)
 
     setEnv("JAEGER_SAMPLER_TYPE", "remote");
     setEnv("JAEGER_SAMPLER_PARAM", "0.33");
-    setEnv("JAEGER_SAMPLER_SERVER_URL", "http://myagent:1234");
+    setEnv("JAEGER_SAMPLING_ENDPOINT", "http://myagent:1234");
 
     setEnv("JAEGER_SERVICE_NAME", "AService");
     setEnv("JAEGER_TAGS", "hostname=foobar,my.app.version=4.5.6");

--- a/src/jaegertracing/samplers/Config.cpp
+++ b/src/jaegertracing/samplers/Config.cpp
@@ -36,10 +36,14 @@ void Config::fromEnv()
     const auto param = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_PARAM_ENV_PROP);
     if (!param.empty()) {
         std::istringstream iss(param);
-        int paramVal = 0;
+        double paramVal = 0;
         if (iss >> paramVal) {
             _param = paramVal;
         }
+    }
+    const auto samplingServerURL = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_SERVER_URL_ENV_PROP);
+    if (!samplingServerURL.empty()) {
+        _samplingServerURL = samplingServerURL;
     }
 }
 

--- a/src/jaegertracing/samplers/Config.cpp
+++ b/src/jaegertracing/samplers/Config.cpp
@@ -41,7 +41,7 @@ void Config::fromEnv()
             _param = paramVal;
         }
     }
-    const auto samplingServerURL = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLER_SERVER_URL_ENV_PROP);
+    const auto samplingServerURL = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLING_ENDPOINT_ENV_PROP);
     if (!samplingServerURL.empty()) {
         _samplingServerURL = samplingServerURL;
     }

--- a/src/jaegertracing/samplers/Config.h
+++ b/src/jaegertracing/samplers/Config.h
@@ -47,7 +47,7 @@ class Config {
 
     static constexpr auto kJAEGER_SAMPLER_TYPE_ENV_PROP = "JAEGER_SAMPLER_TYPE";
     static constexpr auto kJAEGER_SAMPLER_PARAM_ENV_PROP = "JAEGER_SAMPLER_PARAM";
-    static constexpr auto kJAEGER_SAMPLER_MANAGER_HOST_PORT_ENV_PROP = "JAEGER_SAMPLER_MANAGER_HOST_PORT";
+    static constexpr auto kJAEGER_SAMPLER_SERVER_URL_ENV_PROP = "JAEGER_SAMPLER_SERVER_URL";
 
     static Clock::duration defaultSamplingRefreshInterval()
     {

--- a/src/jaegertracing/samplers/Config.h
+++ b/src/jaegertracing/samplers/Config.h
@@ -47,7 +47,7 @@ class Config {
 
     static constexpr auto kJAEGER_SAMPLER_TYPE_ENV_PROP = "JAEGER_SAMPLER_TYPE";
     static constexpr auto kJAEGER_SAMPLER_PARAM_ENV_PROP = "JAEGER_SAMPLER_PARAM";
-    static constexpr auto kJAEGER_SAMPLER_SERVER_URL_ENV_PROP = "JAEGER_SAMPLER_SERVER_URL";
+    static constexpr auto kJAEGER_SAMPLING_ENDPOINT_ENV_PROP = "JAEGER_SAMPLING_ENDPOINT";
 
     static Clock::duration defaultSamplingRefreshInterval()
     {


### PR DESCRIPTION
fix conversion to double of JAEGER_SAMPLER_PARAM
rename env var JAEGER_SAMPLER_MANAGER_HOST_PORT to JAEGER_SAMPLER_SERVER_URL
properly load JAEGER_SAMPLER_SERVER_URL

Signed-off-by: CI-Bot for Emmanuel Courreges <emmanuel.courreges@orange.com>