### PR TITLE
print errors when environment variable conversions to int or double fail

### DIFF
--- a/src/jaegertracing/Config.cpp
+++ b/src/jaegertracing/Config.cpp
@@ -53,6 +53,9 @@ void Config::fromEnv()
                 std::getline(tagStream, tagValue, '=');
                 if (std::getline(tagStream, tagValue, '=')) {
                     // error, should be logged somewhere
+                    std::cerr << "wrong format in tag " << tagKey
+                    << " of env var " << kJAEGER_TAGS_ENV_PROP
+                    << ", it can not contain an =\n";
                 }
                 else {
                     _tags.emplace_back(tagKey, tagValue);

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -118,6 +118,9 @@ TEST(Config, testFromEnv)
                   "test-service",
                   tags);
 
+    // In case the test computer has env set
+    testutils::EnvVariable::resetEnv();
+    // Make sure fromEnv has no effect if env not set
     config.fromEnv();
 
     ASSERT_EQ(std::string("http://host36:56568"), config.reporter().endpoint());
@@ -199,17 +202,7 @@ TEST(Config, testFromEnv)
     ASSERT_EQ(std::string("host33:445"),
               config.reporter().localAgentHostPort());
 
-    testutils::EnvVariable::setEnv("JAEGER_AGENT_HOST", "");
-    testutils::EnvVariable::setEnv("JAEGER_AGENT_PORT", "");
-    testutils::EnvVariable::setEnv("JAEGER_ENDPOINT", "");
-    testutils::EnvVariable::setEnv("JAEGER_REPORTER_MAX_QUEUE_SIZE", "");
-    testutils::EnvVariable::setEnv("JAEGER_REPORTER_FLUSH_INTERVAL", "");
-    testutils::EnvVariable::setEnv("JAEGER_REPORTER_LOG_SPANS", "");
-    testutils::EnvVariable::setEnv("JAEGER_SAMPLER_PARAM", "");
-    testutils::EnvVariable::setEnv("JAEGER_SAMPLER_TYPE", "");
-    testutils::EnvVariable::setEnv("JAEGER_SERVICE_NAME", "");
-    testutils::EnvVariable::setEnv("JAEGER_TAGS", "");
-    testutils::EnvVariable::setEnv("JAEGER_DISABLED", "");
+    testutils::EnvVariable::resetEnv();
 }
 
 }  // namespace jaegertracing

--- a/src/jaegertracing/reporters/Config.cpp
+++ b/src/jaegertracing/reporters/Config.cpp
@@ -72,16 +72,12 @@ void Config::fromEnv()
         _localAgentHostPort = oss.str();
     }
     const auto agentPort =
-        utils::EnvVariable::getStringVariable(kJAEGER_AGENT_PORT_ENV_PROP);
-    if (!agentPort.empty()) {
-        std::istringstream iss(agentPort);
-        int port = 0;
-        if (iss >> port) {
-            auto agentHostPort = net::IPAddress::parse(_localAgentHostPort);
-            std::ostringstream oss;
-            oss << agentHostPort.first << ":" << port;
-            _localAgentHostPort = oss.str();
-        }
+        utils::EnvVariable::getIntVariable(kJAEGER_AGENT_PORT_ENV_PROP);
+    if (agentPort.first && (agentPort.second > 0) && (agentPort.second <= USHRT_MAX)) {
+        auto agentHostPort = net::IPAddress::parse(_localAgentHostPort);
+        std::ostringstream oss;
+        oss << agentHostPort.first << ":" << agentPort.second;
+        _localAgentHostPort = oss.str();
     }
 
     const auto endpoint =
@@ -98,19 +94,15 @@ void Config::fromEnv()
 
     const auto flushInterval = utils::EnvVariable::getIntVariable(
         kJAEGER_REPORTER_FLUSH_INTERVAL_ENV_PROP);
-    if (!flushInterval.first) {
-        if (flushInterval.second > 0) {
-            _bufferFlushInterval =
-                std::chrono::milliseconds(flushInterval.second);
-        }
+    if (flushInterval.first && (flushInterval.second > 0) ) {
+        _bufferFlushInterval =
+            std::chrono::milliseconds(flushInterval.second);
     }
 
     const auto maxQueueSize = utils::EnvVariable::getIntVariable(
         kJAEGER_REPORTER_MAX_QUEUE_SIZE_ENV_PROP);
-    if (!maxQueueSize.first) {
-        if (maxQueueSize.second > 0) {
-            _queueSize = maxQueueSize.second;
-        }
+    if (maxQueueSize.first &&  (maxQueueSize.second > 0) ) {
+        _queueSize = maxQueueSize.second;
     }
 }
 

--- a/src/jaegertracing/samplers/Config.cpp
+++ b/src/jaegertracing/samplers/Config.cpp
@@ -40,6 +40,10 @@ void Config::fromEnv()
         if (iss >> paramVal) {
             _param = paramVal;
         }
+        else {
+            std::cerr << "Failed to convert env var " << kJAEGER_SAMPLER_PARAM_ENV_PROP << ": "
+            << param << " to a double, using instead " << _param << std::endl;
+        }
     }
     const auto samplingServerURL = utils::EnvVariable::getStringVariable(kJAEGER_SAMPLING_ENDPOINT_ENV_PROP);
     if (!samplingServerURL.empty()) {

--- a/src/jaegertracing/testutils/EnvVariable.h
+++ b/src/jaegertracing/testutils/EnvVariable.h
@@ -31,6 +31,20 @@ inline void setEnv(const char *variable, const char *value) {
 #endif
 }
 
+inline void resetEnv() {
+    setEnv("JAEGER_AGENT_HOST", "");
+    setEnv("JAEGER_AGENT_PORT", "");
+    setEnv("JAEGER_ENDPOINT", "");
+    setEnv("JAEGER_REPORTER_MAX_QUEUE_SIZE", "");
+    setEnv("JAEGER_REPORTER_FLUSH_INTERVAL", "");
+    setEnv("JAEGER_REPORTER_LOG_SPANS", "");
+    setEnv("JAEGER_SAMPLER_PARAM", "");
+    setEnv("JAEGER_SAMPLER_TYPE", "");
+    setEnv("JAEGER_SERVICE_NAME", "");
+    setEnv("JAEGER_TAGS", "");
+    setEnv("JAEGER_DISABLED", "");
+}
+
 }  // namespace EnvVariable
 }  // namespace testutils
 }  // namespace jaegertracing

--- a/src/jaegertracing/utils/EnvVariable.h
+++ b/src/jaegertracing/utils/EnvVariable.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <sstream>
 #include <algorithm>
+#include <iostream>
 
 namespace jaegertracing {
 namespace utils {
@@ -31,6 +32,7 @@ inline std::string getStringVariable(const char* envVar)
     return std::string(rawVariable ? rawVariable : "");
 }
 
+/// @return pair<true, value> if non empty and conversion ok, pair<false,0> if empty
 inline std::pair<bool, int> getIntVariable(const char* envVar)
 {
     const auto rawVariable = std::getenv(envVar);
@@ -39,12 +41,16 @@ inline std::pair<bool, int> getIntVariable(const char* envVar)
         std::istringstream iss(variable);
         int intVal = 0;
         if (iss >> intVal) {
-            return std::make_pair(false, intVal);
+            return std::make_pair(true, intVal);
+        }
+        else {
+            std::cerr << "Failed to convert env var " << envVar << ": " << rawVariable << " to an int\n";
         }
     }
     return std::make_pair(false, 0);
 }
 
+/// @return pair<true, value> if non empty and conversion ok, pair<false,0> if empty
 inline std::pair<bool, bool> getBoolVariable(const char* envVar)
 {
     const auto rawVariable = std::getenv(envVar);


### PR DESCRIPTION
Signed-off-by: CI-Bot for Emmanuel Courreges <emmanuel.courreges@orange.com>

## Which problem is this PR solving?
Probably should log a warning if value cannot be parsed. But it's not in scope for this PR.
_Originally posted by @yurishkuro in https://github.com/jaegertracing/jaeger-client-cpp/pull/200_

## Short description of the changes
Log failure information on std::cerr for every conversion error of environment variable to int or to double.
The config is loaded from env when we don't have a logger yet, that's why there is no alternative to std:cerr which was already used in similar cases.
