### PR TITLE
Replace opentracing-static with opentracing shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,14 +72,8 @@ hunter_add_package(opentracing-cpp)
 # Not `${hunter_config}` because OpenTracing provides its own
 # OpenTracingConfig.cmake file
 find_package(OpenTracing CONFIG REQUIRED)
-# Under Windows, link dynamically with OpenTracing
-if (WIN32)
-  list(APPEND LIBS OpenTracing::opentracing)
-  set(OPENTRACING_LIB OpenTracing::opentracing)
-else()
-  list(APPEND LIBS OpenTracing::opentracing-static)
-  set(OPENTRACING_LIB OpenTracing::opentracing-static)
-endif()
+list(APPEND LIBS OpenTracing::opentracing)
+set(OPENTRACING_LIB OpenTracing::opentracing)
 list(APPEND package_deps OpenTracing)
 
 hunter_add_package(nlohmann_json)


### PR DESCRIPTION
For hunter disabled builds Jaeger requires and searches for
opentracing shared library not just for Win32, but for Linux
as well. It would be nice to always make use of opentracing
shared library instead of using static one.

Fixes: https://github.com/jaegertracing/jaeger-client-cpp/issues/162
Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>
```
[ 50%] Linking CXX shared library libjaegertracing.so
/usr/bin/ld: /usr/local/lib/libopentracing.a(propagation.cpp.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: /usr/local/lib/libopentracing.a(dynamic_load.cpp.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: /usr/local/lib/libopentracing.a(noop.cpp.o): relocation R_X86_64_32 against undefined symbol `__pthread_key_create' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: /usr/local/lib/libopentracing.a(tracer.cpp.o): relocation R_X86_64_32 against undefined symbol `__pthread_key_create' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: /usr/local/lib/libopentracing.a(tracer_factory.cpp.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: nonrepresentable section on output
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/jaegertracing.dir/build.make:1437: libjaegertracing.so.0.5.0] Error 1
make[1]: *** [CMakeFiles/Makefile2:107: CMakeFiles/jaegertracing.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-

## Short description of the changes
-
