### PR TITLE
Update OpenTracing to 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,6 @@ matrix:
     env:
     - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Release
       -DJAEGERTRACING_PLUGIN=ON -DBUILD_TESTING=ON -DHUNTER_CONFIGURATION_TYPES=Release'"
-branches:
-  only:
-  - master
 before_install:
 - eval "${MATRIX_EVAL}"
 - mkdir cmake-download && cd cmake-download && curl -O https://cmake.org/files/v3.10/cmake-3.10.0-rc5-Linux-x86_64.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,9 @@ include(HunterGate)
 option(HUNTER_BUILD_SHARED_LIBS "Build Shared Library" ON)
 
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.201.tar.gz"
-    SHA1 "29f10683f10c7b35e1f599d71542af0c2daa6a01"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.23.249.tar.gz"
+    SHA1 "d45d77d8bba9da13e9290a180e0477e90accd89b"
+    LOCAL # load `${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/config.cmake`
 )
 
 project(jaegertracing VERSION 0.5.0)
@@ -341,7 +342,7 @@ if(BUILD_TESTING)
       src/jaegertracing/utils/UDPSenderTest.cpp
       src/jaegertracing/utils/HTTPTransporterTest.cpp)
   target_link_libraries(
-      UnitTest PRIVATE testutils GTest::main ${JAEGERTRACING_LIB})
+      UnitTest PRIVATE testutils PUBLIC GTest::main ${JAEGERTRACING_LIB})
   add_test(NAME UnitTest COMMAND UnitTest)
 
   update_path_for_test(UnitTest)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,0 +1,1 @@
+hunter_config(GTest VERSION 1.8.0-hunter-p11)

--- a/src/jaegertracing/Span.cpp
+++ b/src/jaegertracing/Span.cpp
@@ -76,7 +76,7 @@ void Span::SetBaggageItem(opentracing::string_view restrictedKey,
                              value,
                              [this](std::vector<Tag>::const_iterator first,
                                     std::vector<Tag>::const_iterator last) {
-                                 logFieldsNoLocking(first, last);
+                                 logFieldsNoLocking(SystemClock::now(), first, last);
                              });
     _context = _context.withBaggage(baggage);
 }

--- a/src/jaegertracing/Span.h
+++ b/src/jaegertracing/Span.h
@@ -190,24 +190,27 @@ class Span : public opentracing::Span {
                                                      : itr->second;
     }
 
+    void Log(opentracing::SystemTime timestamp,
+             std::initializer_list<
+                 std::pair<opentracing::string_view, opentracing::Value>>
+                 fieldPairs) noexcept override
+    {
+        doLog(timestamp, fieldPairs);
+    }
+
+    void Log(opentracing::SystemTime timestamp,
+             const std::vector<
+                 std::pair<opentracing::string_view, opentracing::Value>>&
+                 fieldPairs) noexcept override
+    {
+        doLog(timestamp, fieldPairs);
+    }
+
     void Log(std::initializer_list<
              std::pair<opentracing::string_view, opentracing::Value>>
                  fieldPairs) noexcept override
     {
-        std::lock_guard<std::mutex> lock(_mutex);
-        if (!_context.isSampled()) {
-            return;
-        }
-
-        std::vector<Tag> fields;
-        fields.reserve(fieldPairs.size());
-        std::transform(
-            std::begin(fieldPairs),
-            std::end(fieldPairs),
-            std::back_inserter(fields),
-            [](const std::pair<opentracing::string_view, opentracing::Value>&
-                   pair) { return Tag(pair.first, pair.second); });
-        logFieldsNoLocking(std::begin(fields), std::end(fields));
+        doLog(SystemClock::now(), fieldPairs);
     }
 
     const SpanContext& context() const noexcept override
@@ -228,10 +231,29 @@ class Span : public opentracing::Span {
     bool isFinished() const { return _duration != SteadyClock::duration(); }
 
     template <typename FieldIterator>
-    void logFieldsNoLocking(FieldIterator first, FieldIterator last) noexcept
+    void logFieldsNoLocking(const std::chrono::system_clock::time_point& timestamp, FieldIterator first, FieldIterator last) noexcept
     {
-        LogRecord log(SystemClock::now(), first, last);
+        LogRecord log(timestamp, first, last);
         _logs.push_back(log);
+    }
+
+    template <typename Container>
+    void doLog(opentracing::SystemTime timestamp, Container fieldPairs) noexcept
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (!_context.isSampled()) {
+            return;
+        }
+
+        std::vector<Tag> fields;
+        fields.reserve(fieldPairs.size());
+        std::transform(
+            std::begin(fieldPairs),
+            std::end(fieldPairs),
+            std::back_inserter(fields),
+            [](const std::pair<opentracing::string_view, opentracing::Value>&
+                   pair) { return Tag(pair.first, pair.second); });
+        logFieldsNoLocking(timestamp, std::begin(fields), std::end(fields));
     }
 
     void setSamplingPriority(const opentracing::Value& value);

--- a/src/jaegertracing/SpanContext.h
+++ b/src/jaegertracing/SpanContext.h
@@ -167,7 +167,7 @@ class SpanContext : public opentracing::SpanContext {
         forEachBaggageItem(f);
     }
 
-    std::unique_ptr<opentracing::SpanContext> Clone() const noexcept
+    std::unique_ptr<opentracing::SpanContext> Clone() const noexcept override
     {
         std::lock_guard<std::mutex> lock(_mutex);
         return std::unique_ptr<opentracing::SpanContext>(

--- a/src/jaegertracing/TracerTest.cpp
+++ b/src/jaegertracing/TracerTest.cpp
@@ -58,6 +58,11 @@ class FakeSpanContext : public opentracing::SpanContext {
     {
         // Do nothing
     }
+
+    virtual std::unique_ptr<SpanContext> Clone() const noexcept override
+    {
+        return std::unique_ptr<FakeSpanContext>(new FakeSpanContext());
+    }
 };
 
 template <typename BaseWriter>


### PR DESCRIPTION

## Which problem is this PR solving?
- This solves the request #189 

## Short description of the changes
- Update the version of OpenTracing to 1.6.0
- GTest version was fixed to 1.8.0-hunter-p11 because the later versions seem to have a problem with the rpath making the unit test fail because the binaries are unable to locate the gtest libraries. This issue will be followed separately to avoid blocking this request.

This will also solve another problem reported by @Alek86 in #208. This was due to a bug in OpenTracing compile flags that was fixed with the latest release.
