### PR TITLE
Adding x-b3-* headers parsing and propagating support

### DIFF
--- a/src/jaegertracing/Constants.h.in
+++ b/src/jaegertracing/Constants.h.in
@@ -37,7 +37,11 @@ static constexpr auto kSamplerTypeRemote = "remote";
 static constexpr auto kSamplerTypeProbabilistic = "probabilistic";
 static constexpr auto kSamplerTypeRateLimiting = "ratelimiting";
 static constexpr auto kSamplerTypeLowerBound = "lowerbound";
-
+static constexpr auto kB3TraceHeaderPrefix = "x-b3-";
+static constexpr auto kB3TraceIdHeaderName = "x-b3-traceid";
+static constexpr auto kB3SpanIdHeaderName = "x-b3-spanid";
+static constexpr auto kB3ParentSpanIdHeaderName = "x-b3-parentspanid";
+static constexpr auto kB3SampledHeaderName = "x-b3-sampled";
 }  // namespace jaegertracing
 
 #endif  // JAEGERTRACING_CONSTANTS_H

--- a/src/jaegertracing/Tracer.cpp
+++ b/src/jaegertracing/Tracer.cpp
@@ -102,12 +102,18 @@ Tracer::StartSpanWithOptions(string_view operationName,
         else {
             const auto traceID = parent->traceID();
             const auto spanID = randomID();
+            // TODO - Review orig code
+            // Shouldnt parentId be from parentID or is it because its ignored ?
             const auto parentID = parent->spanID();
             const auto flags = parent->flags();
-            ctx = SpanContext(traceID, spanID, parentID, flags, StrMap());
+            const auto b3Headers = parent->B3Headers();
+            ctx = SpanContext(traceID, spanID, parentID, flags, StrMap(),
+                    "", b3Headers);
         }
 
         if (parent && !parent->baggage().empty()) {
+            // TODO - Review do we need b3 here? Other spancontext params
+            // also not passed
             ctx = ctx.withBaggage(parent->baggage());
         }
 

--- a/src/jaegertracing/Tracer.cpp
+++ b/src/jaegertracing/Tracer.cpp
@@ -106,9 +106,11 @@ Tracer::StartSpanWithOptions(string_view operationName,
             // Shouldnt parentId be from parentID or is it because its ignored ?
             const auto parentID = parent->spanID();
             const auto flags = parent->flags();
-            const auto b3Headers = parent->B3Headers();
+            TracerType type = parent->tracerType();
+            type = TracerType::TRACER_TYPE_B3;
+
             ctx = SpanContext(traceID, spanID, parentID, flags, StrMap(),
-                    "", b3Headers);
+                    "", type);
         }
 
         if (parent && !parent->baggage().empty()) {

--- a/src/jaegertracing/TracerTest.cpp
+++ b/src/jaegertracing/TracerTest.cpp
@@ -454,6 +454,24 @@ TEST(Tracer, testPropagation)
         ASSERT_TRUE(static_cast<bool>(extractedCtx));
         ASSERT_EQ(3, extractedCtx->baggage().size());
         ASSERT_EQ(ctx, *extractedCtx);
+        
+        // Test b3- 
+        headerMap.clear();
+        headerMap[kB3TraceIdHeaderName] = "8a36814379ee00aab1d424a9134adca1";
+        headerMap[kB3SpanIdHeaderName] = "b1cf504cf04e96b4";
+        headerMap[kB3ParentSpanIdHeaderName] = "c18983619541935d";
+        headerMap[kB3SampledHeaderName] = "1";
+        result = tracer->Extract(headerReader);
+        ASSERT_TRUE(static_cast<bool>(result));
+        extractedCtx.reset(static_cast<SpanContext*>(result->release()));
+        extractedCtx->print(std::cout);
+        headerMap.clear();
+        tracer->Inject(*extractedCtx, headerWriter);
+        for (auto itr = std::begin(headerMap); itr != std::end(headerMap); ++itr) {
+            std::cout<<std::endl<<itr->first<<":"<<itr->second;
+        }
+        std::cout<<std::endl;
+        ASSERT_EQ(4, headerMap.size());
     }
     tracer->Close();
 }

--- a/src/jaegertracing/propagation/B3Tracer.cpp
+++ b/src/jaegertracing/propagation/B3Tracer.cpp
@@ -1,0 +1,113 @@
+#include "jaegertracing/propagation/Propagator.h"
+#include "jaegertracing/propagation/B3Tracer.h"
+
+namespace jaegertracing {
+namespace propagation {
+
+#if 0
+void B3Tracer::set(Propagator* p) const
+{
+    _p = p;
+}
+#endif
+template <typename ReaderType, typename WriterType>
+SpanContext B3Tracer<ReaderType, WriterType>::extractImpl(const Propagator<ReaderType, WriterType>* p, const Reader& reader) const
+{
+    using StrMap = SpanContext::StrMap;
+    std::cout << "B3 Extraction" << std::endl;
+    SpanContext ctx;
+    StrMap baggage;
+    std::string debugID;
+    std::string b3TraceId;
+    std::string b3SpanId;
+    std::string b3ParentSpanId;
+    std::string b3Sampled;
+
+    const auto result = reader.ForeachKey(
+            [&debugID, &baggage, &b3TraceId, &b3SpanId, &b3ParentSpanId,
+            &b3Sampled, &p](const std::string& rawKey, const std::string& value) {
+            const auto key = p->normalizeKey(rawKey);
+            if (key == p->_headerKeys.jaegerDebugHeader()) {
+            debugID = value;
+            }
+            else if (key == p->_headerKeys.jaegerBaggageHeader()) {
+            for (auto&& pair : p->parseCommaSeparatedMap(value)) {
+            baggage[pair.first] = pair.second;
+            }
+            }
+            else if (key == kB3TraceIdHeaderName) {
+            b3TraceId = p->decodeValue(value);
+            }
+            else if (key == kB3SpanIdHeaderName) {
+            b3SpanId = p->decodeValue(value);
+            }
+            else if (key == kB3ParentSpanIdHeaderName) {
+            b3ParentSpanId = p->decodeValue(value);
+            }
+            else if (key == kB3SampledHeaderName) {
+                b3Sampled = p->decodeValue(value);
+            }
+            else {
+                const auto prefix = p->_headerKeys.traceBaggageHeaderPrefix();
+                if (key.size() >= prefix.size() &&
+                        key.substr(0, prefix.size()) == prefix) {
+                    const auto safeKey = p->removeBaggageKeyPrefix(key);
+                    const auto safeValue = p->decodeValue(value);
+                    baggage[safeKey] = safeValue;
+                }
+            }
+            return opentracing::make_expected();
+            });
+
+    if (!b3TraceId.empty() && !b3SpanId.empty() && !b3ParentSpanId.empty() &&
+            !b3Sampled.empty()) {
+        std::istringstream issB3(b3TraceId+":"+b3SpanId+":"+b3ParentSpanId+":"+b3Sampled);
+        if (!(issB3 >> ctx) || ctx == SpanContext())
+            return SpanContext();
+    }
+
+    if (!result &&
+            result.error() == opentracing::span_context_corrupted_error) {
+        p->_metrics->decodingErrors().inc(1);
+        return SpanContext();
+    }
+
+    if (!ctx.traceID().isValid() && debugID.empty() && baggage.empty()) {
+        return SpanContext();
+    }
+
+    int flags = ctx.flags();
+    if (!debugID.empty()) {
+        flags |= static_cast<unsigned char>(SpanContext::Flag::kDebug) |
+            static_cast<unsigned char>(SpanContext::Flag::kSampled);
+    }
+    return SpanContext(ctx.traceID(),
+            ctx.spanID(),
+            ctx.parentID(),
+            flags,
+            baggage,
+            debugID,
+            TracerType::TRACER_TYPE_B3);
+}
+
+template <typename ReaderType, typename WriterType>
+void B3Tracer<ReaderType, WriterType>::inject(const Propagator<ReaderType, WriterType>* p, const SpanContext& ctx, const Writer& writer) const
+{
+    std::ostringstream ss;
+    ss << ctx.traceID();
+    writer.Set(kB3TraceIdHeaderName, ss.str());
+    ss.str(std::string());
+    ss.clear();
+    ss << std::hex << ctx.spanID();
+    writer.Set(kB3SpanIdHeaderName, ss.str());
+    ss.str(std::string());
+    ss.clear();
+    ss << std::hex << ctx.parentID();
+    writer.Set(kB3ParentSpanIdHeaderName, ss.str());
+    writer.Set(kB3SampledHeaderName, std::to_string(ctx.isSampled()));
+}
+
+
+}
+}
+

--- a/src/jaegertracing/propagation/B3Tracer.h
+++ b/src/jaegertracing/propagation/B3Tracer.h
@@ -1,0 +1,28 @@
+#ifndef JAEGERTRACING_B3TRACER_H
+#define JAEGERTRACING_B3TRACER_H
+
+namespace jaegertracing {
+namespace propagation {
+
+template<typename ReaderT, typename WriterT>
+class Propagator;
+
+class HeadersConfig;
+
+template <typename ReaderType, typename WriterType>
+class B3Tracer
+{
+  public:
+    using Reader = ReaderType;
+    using Writer = WriterType;
+
+    B3Tracer() = default;
+    ~B3Tracer() = default;
+
+    SpanContext extractImpl(const Propagator<ReaderType, WriterType>* p, const Reader& reader) const;
+    void inject(const Propagator<ReaderType, WriterType>* p, const SpanContext& ctx, const Writer& writer) const;
+};
+}
+}
+#include "B3Tracer.cpp"
+#endif

--- a/src/jaegertracing/propagation/UberTracer.cpp
+++ b/src/jaegertracing/propagation/UberTracer.cpp
@@ -1,0 +1,93 @@
+#include "jaegertracing/propagation/Propagator.h"
+#include "jaegertracing/propagation/UberTracer.h"
+
+namespace jaegertracing {
+namespace propagation {
+#if 0
+void UberTracer::set(Propagator* p) const
+{
+    _p = p;
+}
+#endif
+
+template <typename ReaderType, typename WriterType>
+SpanContext UberTracer<ReaderType, WriterType>::extractImpl(const Propagator<ReaderType, WriterType>* p, const Reader& reader) const
+{
+    using StrMap = SpanContext::StrMap;
+    std::cout << "UBER Extraction" << std::endl;
+    SpanContext ctx;
+    StrMap baggage;
+    std::string debugID;
+
+    const auto result = reader.ForeachKey(
+            [&ctx, &debugID, &baggage,
+            &p](const std::string& rawKey, const std::string& value) {
+            const auto key = p->normalizeKey(rawKey);
+            if (key == p->_headerKeys.traceContextHeaderName()) {
+            const auto safeValue = p->decodeValue(value);
+            std::istringstream iss(safeValue);
+            if (!(iss >> ctx) || ctx == SpanContext()) {
+            return opentracing::make_expected_from_error<void>(
+                opentracing::span_context_corrupted_error);
+            }
+            }
+            else if (key == p->_headerKeys.jaegerDebugHeader()) {
+            debugID = value;
+            }
+            else if (key == p->_headerKeys.jaegerBaggageHeader()) {
+            for (auto&& pair : p->parseCommaSeparatedMap(value)) {
+            baggage[pair.first] = pair.second;
+            std::cout<<"1-ADD:"<<pair.first<<"::"<<pair.second<<std::endl;
+            }
+            }
+            else {
+                const auto prefix = p->_headerKeys.traceBaggageHeaderPrefix();
+                if (key.size() >= prefix.size() &&
+                        key.substr(0, prefix.size()) == prefix) {
+                    const auto safeKey = p->removeBaggageKeyPrefix(key);
+                    const auto safeValue = p->decodeValue(value);
+                    baggage[safeKey] = safeValue;
+                    std::cout<<"2-ADD:"<<safeKey<<"::"<<safeValue<<std::endl;
+                }
+            }
+            return opentracing::make_expected();
+            });
+
+    if (!result &&
+            result.error() == opentracing::span_context_corrupted_error) {
+        p->_metrics->decodingErrors().inc(1);
+        return SpanContext();
+    }
+
+    if (!ctx.traceID().isValid() && debugID.empty() && baggage.empty()) {
+        return SpanContext();
+    }
+
+    int flags = ctx.flags();
+    if (!debugID.empty()) {
+        flags |= static_cast<unsigned char>(SpanContext::Flag::kDebug) |
+            static_cast<unsigned char>(SpanContext::Flag::kSampled);
+    }
+
+    return SpanContext(ctx.traceID(),
+            ctx.spanID(),
+            ctx.parentID(),
+            flags,
+            baggage,
+            debugID,
+            TracerType::TRACER_TYPE_UBER);
+
+}
+
+template <typename ReaderType, typename WriterType>
+void UberTracer<ReaderType, WriterType>::inject(const Propagator<ReaderType, WriterType>* p, const SpanContext& ctx, const Writer& writer) const
+{
+    std::ostringstream oss;
+    oss << ctx;
+    writer.Set(p->_headerKeys.traceContextHeaderName(), oss.str());
+}
+
+
+
+}
+}

--- a/src/jaegertracing/propagation/UberTracer.h
+++ b/src/jaegertracing/propagation/UberTracer.h
@@ -1,0 +1,32 @@
+#ifndef JAEGERTRACING_UBERTRACER_H
+#define JAEGERTRACING_UBERTRACER_H
+
+namespace jaegertracing {
+namespace propagation {
+
+template<typename ReaderT, typename WriterT>
+class Propagator;
+
+class HeadersConfig;
+
+template <typename ReaderType, typename WriterType>
+class UberTracer
+{
+  public:
+
+    using Reader = ReaderType;
+    using Writer = WriterType;
+
+    UberTracer() = default;
+    ~UberTracer() = default;
+    //void set(Propagator* p) const;
+ 
+    SpanContext  extractImpl(const Propagator<ReaderType, WriterType>* p, const Reader& reader) const;
+    void inject(const Propagator<ReaderType, WriterType>* p, const SpanContext& ctx, const Writer& writer) const;
+};
+
+}
+}
+#include "UberTracer.cpp"
+
+#endif


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #125 and probably  #141

## Short description of the changes
- The changes are parse / decode the tracing information received in x-b3-traceId, x-b3-spanId, x-b3-parentspanId, x-b3-sampled and to propagate them further. 
