### PR TITLE
update config.cmake

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,1 +1,1 @@
-hunter_config(GTest VERSION 1.8.0-hunter-p11)
+hunter_config(GTest VERSION 1.8.0-hunter-p11 CMAKE_ARGS BUILD_GMOCK=OFF BUILD_GTEST=ON)


### PR DESCRIPTION
#211 GTEST failure while running cmake

Which problem is this PR solving?
- Resolves #211 opened by @suab321321. Incorrect usage of hunter_config which was resolved by adding new parameter.

## Short description of the changes
- Added CMAKE_ARGS BUILD_GMOCK=OFF BUILD_GTEST=ON in config.cmake
