### PR TITLE
add Findnlohmann_json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ endif()
 list(APPEND package_deps OpenTracing)
 
 hunter_add_package(nlohmann_json)
-find_package(nlohmann_json CONFIG REQUIRED)
+find_package(nlohmann_json 2.1.0 ${hunter_config} REQUIRED)
 list(APPEND LIBS nlohmann_json::nlohmann_json)
 list(APPEND package_deps nlohmann_json)
 

--- a/cmake/Findnlohmann_json.cmake
+++ b/cmake/Findnlohmann_json.cmake
@@ -1,0 +1,64 @@
+# Find jsoncpp
+#
+# Find the nlohmann json header
+#
+# if you nee to add a custom library search path, do it via via CMAKE_PREFIX_PATH
+#
+# This module defines
+#
+#  nlohmann_json_INCLUDE_DIR, where to find header, etc.
+#
+#  nlohmann_json_FOUND, If false, do not try to use jsoncpp.
+#
+#  nlohmann_json_LIBRARIES, empty since no linkage is required, this
+#      is a header-only library.
+#
+#  nlohmann_json_INCLUDE_NAME, the actual header name. You only have
+#      to use this if you want to support 2.0.x which installs
+#      a top-level json.hpp instead of nlohmann/json.hpp
+#
+
+# only look in default directories
+set(nlohmann_json_INCLUDE_NAME "nlohmann/json.hpp")
+find_path(
+	nlohmann_json_INCLUDE_DIR
+	NAMES "${nlohmann_json_INCLUDE_NAME}"
+	DOC "nlohmann json include dir"
+)
+
+if (NOT nlohmann_json_INCLUDE_DIR)
+	set(nlohmann_json_INCLUDE_NAME "json.hpp")
+	find_path(
+		nlohmann_json_INCLUDE_DIR
+		NAMES "${nlohmann_json_INCLUDE_NAME}"
+	)
+endif()
+
+set(nlohmann_json_INCLUDE_NAME ${nlohmann_json_INCLUDE_NAME} CACHE STRING "nlohmann header file name")
+
+set(nlohmann_json_LIBRARIES NOTFOUND CACHE STRING "no library is required by nlohmann_json")
+
+# Version detection. Unfortunately the header doesn't expose a proper version
+# define.
+if (nlohmann_json_INCLUDE_DIR AND nlohmann_json_INCLUDE_NAME)
+	file(READ "${nlohmann_json_INCLUDE_DIR}/${nlohmann_json_INCLUDE_NAME}" NL_HDR_TXT LIMIT 1000)
+	if (NL_HDR_TXT MATCHES "version ([0-9]+\.[0-9]+\.[0-9]+)")
+		set(nlohmann_json_VERSION "${CMAKE_MATCH_1}")
+	endif()
+endif()
+
+set(nlohmann_json_VERSION "${nlohmann_json_VERSION}" CACHE STRING "nlohmann header version")
+
+# handle the QUIETLY and REQUIRED arguments and set nlohmann_json_FOUND to TRUE
+# if all listed variables are TRUE, hide their existence from configuration view
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+	nlohmann_json
+	REQUIRED_VARS nlohmann_json_INCLUDE_DIR nlohmann_json_INCLUDE_NAME
+	VERSION_VAR nlohmann_json_VERSION)
+
+add_library(nlohmann_json INTERFACE IMPORTED)
+
+set_target_properties(nlohmann_json PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${nlohmann_json_INCLUDE_DIR}"
+)


### PR DESCRIPTION
even after json package installed using distro package, cmake
is not able to search for it's cmake config, adding a find_package
method ensures garanteed check on finding dependency, which is either
skipped or not discovered.

Reference:

CMake Error at CMakeLists.txt:80 (find_package):
  Could not find a package configuration file provided by "nlohmann_json"
  with any of the following names:

    nlohmann_jsonConfig.cmake
    nlohmann_json-config.cmake

  Add the installation prefix of "nlohmann_json" to CMAKE_PREFIX_PATH or set
  "nlohmann_json_DIR" to a directory containing one of the above files.  If
  "nlohmann_json" provides a separate development package or SDK, be sure it
  has been installed.

Adapted from: https://github.com/jaegertracing/jaeger-client-cpp/pull/46
Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-

## Short description of the changes
-
