### PR TITLE
Fall back to boost::regex when compiling under gcc <4.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,15 @@ endif()
 
 set(package_deps)
 
+# fall back to boost::regex for gcc 4.8.x and earlier
+# (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53631)
+set(BOOST_MIN_VERSION 1.55)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
-  message(FATAL_ERROR "Must use gcc >= 4.9")
+  add_definitions(-DUSE_BOOST_REGEX)
+  hunter_add_package(Boost COMPONENTS regex)
+  find_package(Boost CONFIG REQUIRED regex)
+  list(APPEND LIBS "${Boost_REGEX_LIBRARY_RELEASE}")
 endif()
 
 hunter_add_package(thrift)

--- a/src/jaegertracing/net/URI.cpp
+++ b/src/jaegertracing/net/URI.cpp
@@ -20,7 +20,13 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+
+#ifdef USE_BOOST_REGEX
+#include <boost/regex.hpp>
+#else
 #include <regex>
+#endif
+
 #include <cctype>
 
 namespace jaegertracing {
@@ -68,11 +74,19 @@ URI URI::parse(const std::string& uriStr)
 {
     // See https://tools.ietf.org/html/rfc3986 for explanation.
     URI uri;
+#ifdef USE_BOOST_REGEX
+    boost::regex uriRegex(
+        "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?",
+        boost::regex::extended);
+    boost::smatch match;
+    boost::regex_search(uriStr, match, uriRegex);
+#else
     std::regex uriRegex(
         "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?",
         std::regex::extended);
     std::smatch match;
     std::regex_match(uriStr, match, uriRegex);
+#endif
 
     constexpr auto kSchemeIndex = 2;
     constexpr auto kAuthorityIndex = 4;


### PR DESCRIPTION
, because std::regex is broken under gcc-4.8.x (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53631)

Signed-off-by: Joe O'Connor <Joe.OConnor@openet.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves: #179 

## Short description of the changes
- CMakeLists.txt: define USE_BOOST_REGEX and add boost_regex.so dependency if gcc < 4.9, instead of failing the build
- add boost::regex code wrapped inside "#ifdef USE_BOOST_REGEX" 
-- this means the existing std::regex code should be unaffected with gcc>=4.9
