### PR TITLE
Fall back to boost::regex when building with gcc <4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,17 @@ matrix:
         - ubuntu-toolchain-r-test
         packages:
         - *1
+        - g++-4.8
+    env:
+    - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Debug
+      -DBUILD_SHARED_LIBS=ON -DJAEGERTRACING_COVERAGE=ON'"
+  - os: linux
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *1
         - g++-4.9
     env:
     - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,10 @@ set(package_deps)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
-  message(FATAL_ERROR "Must use gcc >= 4.9")
+  add_definitions(-DUSE_BOOST_REGEX)
+  hunter_add_package(Boost COMPONENTS regex)
+  find_package(Boost CONFIG REQUIRED regex)
+  list(APPEND LIBS "${Boost_REGEX_LIBRARY_RELEASE}")
 endif()
 
 hunter_add_package(thrift)

--- a/src/jaegertracing/net/URI.cpp
+++ b/src/jaegertracing/net/URI.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "jaegertracing/net/URI.h"
+#include "jaegertracing/utils/Regex.h"
 
 #include <cassert>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
-#include <regex>
 #include <cctype>
 
 namespace jaegertracing {
@@ -68,11 +68,11 @@ URI URI::parse(const std::string& uriStr)
 {
     // See https://tools.ietf.org/html/rfc3986 for explanation.
     URI uri;
-    std::regex uriRegex(
+    jaegertracing::utils::regex::regex uriRegex(
         "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?",
-        std::regex::extended);
-    std::smatch match;
-    std::regex_match(uriStr, match, uriRegex);
+        jaegertracing::utils::regex::regex::extended);
+    jaegertracing::utils::regex::smatch match;
+    jaegertracing::utils::regex::regex_match(uriStr, match, uriRegex);
 
     constexpr auto kSchemeIndex = 2;
     constexpr auto kAuthorityIndex = 4;

--- a/src/jaegertracing/net/http/Header.h
+++ b/src/jaegertracing/net/http/Header.h
@@ -18,10 +18,10 @@
 #define JAEGERTRACING_NET_HTTP_HEADER_H
 
 #include <cassert>
-#include <regex>
 #include <string>
 
 #include "jaegertracing/net/http/Error.h"
+#include "jaegertracing/utils/Regex.h"
 
 namespace jaegertracing {
 namespace net {
@@ -77,14 +77,14 @@ inline std::istream& readLineCRLF(std::istream& in, std::string& line)
 
 inline void readHeaders(std::istream& in, std::vector<Header>& headers)
 {
-    const std::regex headerPattern("([^:]+): (.+)$");
+    const auto headerPattern = jaegertracing::utils::regex::regex("([^:]+): (.+)$");
     std::string line;
-    std::smatch match;
+    jaegertracing::utils::regex::smatch match;
     while (readLineCRLF(in, line)) {
         if (line.empty()) {
             break;
         }
-        if (!std::regex_match(line, match, headerPattern) || match.size() < 3) {
+        if (!jaegertracing::utils::regex::regex_match(line, match, headerPattern) || match.size() < 3) {
             throw ParseError::make("header", line);
         }
         headers.emplace_back(Header(match[1], match[2]));

--- a/src/jaegertracing/net/http/Request.cpp
+++ b/src/jaegertracing/net/http/Request.cpp
@@ -16,8 +16,7 @@
 
 #include "jaegertracing/net/http/Request.h"
 #include "jaegertracing/net/http/SocketReader.h"
-
-#include <regex>
+#include "jaegertracing/utils/Regex.h"
 
 namespace jaegertracing {
 namespace net {
@@ -32,12 +31,12 @@ Request Request::read(Socket & socket)
 
 Request Request::parse(std::istream& in)
 {
-    const std::regex requestLinePattern(
+    const jaegertracing::utils::regex::regex requestLinePattern(
         "([A-Z]+) ([^ ]+) HTTP/([0-9]\\.[0-9])$");
     std::string line;
-    std::smatch match;
+    jaegertracing::utils::regex::smatch match;
     if (!readLineCRLF(in, line) ||
-        !std::regex_match(line, match, requestLinePattern) ||
+        !jaegertracing::utils::regex::regex_match(line, match, requestLinePattern) ||
         match.size() < 4) {
         throw ParseError::make("request line", line);
     }

--- a/src/jaegertracing/net/http/Response.cpp
+++ b/src/jaegertracing/net/http/Response.cpp
@@ -16,8 +16,8 @@
 
 #include "jaegertracing/net/http/Response.h"
 #include "jaegertracing/net/http/SocketReader.h"
+#include "jaegertracing/utils/Regex.h"
 
-#include <regex>
 #include <sstream>
 #include <stdexcept>
 
@@ -34,11 +34,11 @@ namespace http {
 
 Response Response::parse(std::istream& in)
 {
-    const std::regex statusLinePattern("HTTP/([0-9]\\.[0-9]) ([0-9]+) (.+)$");
+    const jaegertracing::utils::regex::regex statusLinePattern("HTTP/([0-9]\\.[0-9]) ([0-9]+) (.+)$");
     std::string line;
-    std::smatch match;
+    jaegertracing::utils::regex::smatch match;
     if (!readLineCRLF(in, line) ||
-        !std::regex_match(line, match, statusLinePattern) || match.size() < 4) {
+        !jaegertracing::utils::regex::regex_match(line, match, statusLinePattern) || match.size() < 4) {
         throw ParseError::make("status line", line);
     }
     Response response;

--- a/src/jaegertracing/testutils/MockAgent.cpp
+++ b/src/jaegertracing/testutils/MockAgent.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "jaegertracing/testutils/MockAgent.h"
+#include "jaegertracing/utils/Regex.h"
 
-#include <regex>
 #include <thread>
 
 #include <thrift/protocol/TCompactProtocol.h>
@@ -155,7 +155,7 @@ void MockAgent::serveHTTP(std::promise<void>& started)
     _servingHTTP = true;
     started.set_value();
 
-    const std::regex servicePattern("[?&]service=([^?&]+)");
+    const jaegertracing::utils::regex::regex servicePattern("[?&]service=([^?&]+)");
     while (isServingHTTP()) {
         constexpr auto kBufferSize = 256;
         std::array<char, kBufferSize> buffer;
@@ -185,11 +185,11 @@ void MockAgent::serveHTTP(std::promise<void>& started)
                            _httpAddress.authority() + "/baggageRestrictions")) {
                 resource = Resource::kBaggage;
             }
-            std::smatch match;
-            if (!std::regex_search(target, match, servicePattern)) {
+            jaegertracing::utils::regex::smatch match;
+            if (!jaegertracing::utils::regex::regex_search(target, match, servicePattern)) {
                 throw net::http::ParseError("no 'service' parameter");
             }
-            if (std::regex_search(match.suffix().str(), servicePattern)) {
+            if (jaegertracing::utils::regex::regex_search(match.suffix().str(), servicePattern)) {
                 throw net::http::ParseError(
                     "'service' parameter must occur only once");
             }

--- a/src/jaegertracing/utils/Regex.h
+++ b/src/jaegertracing/utils/Regex.h
@@ -1,0 +1,55 @@
+#ifndef JAEGERTRACING_UTILS_REGEX_H
+#define JAEGERTRACING_UTILS_REGEX_H
+
+/*
+ * std::regex wrapper that falls back to boost::regex for gcc 4.8.x, because of
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53631
+ */
+
+#ifdef USE_BOOST_REGEX
+#include <boost/regex.hpp>
+#else
+#include <regex>
+#endif
+
+namespace jaegertracing {
+namespace utils {
+namespace regex {
+
+#ifdef USE_BOOST_REGEX
+    typedef boost::regex regex;
+    typedef boost::smatch smatch;
+
+    inline bool regex_match(const std::string& haystack, boost::smatch& results, const boost::regex& pattern) {
+        return boost::regex_match(haystack, results, pattern);
+    }
+
+    inline bool regex_search(const std::string& haystack, const boost::regex& pattern) {
+        return boost::regex_search(haystack, pattern);
+    }
+    inline bool regex_search(const std::string& haystack, boost::smatch& results, const boost::regex& pattern) {
+        return boost::regex_search(haystack, results, pattern);
+    }
+
+#else
+
+    typedef std::regex regex;
+    typedef std::smatch smatch;
+
+    inline bool regex_match(const std::string& haystack, std::smatch& results, const std::regex& pattern) {
+        return std::regex_match(haystack, results, pattern);
+    }
+
+    inline bool regex_search(const std::string& haystack, const std::regex& pattern) {
+        return std::regex_search(haystack, pattern);
+    }
+
+    inline bool regex_search(const std::string& haystack, std::smatch& results, const std::regex& pattern) {
+        return std::regex_search(haystack, results, pattern);
+    }
+#endif // USE_BOOST_REGEX
+}
+}
+}
+#endif
+


### PR DESCRIPTION
Needed because std::regex is broken in gcc-4.8.x
-- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53631
This change fixes the library on RedHat 7.x, which uses gcc-4.8.5.

Signed-off-by: Joe O'Connor <Joe.OConnor@openet.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves: #179


## Short description of the changes
- removed the #ifdefs from the code as suggested in previous review comment
- instead there is now a utils/Regex.h wrapper
