### PR TITLE
Support configuration for generating 128 bit trace ids

### DIFF
--- a/src/jaegertracing/Config.cpp
+++ b/src/jaegertracing/Config.cpp
@@ -32,6 +32,12 @@ void Config::fromEnv()
         _disabled = disabled.second;
     }
 
+    const auto traceId128Bit =
+        utils::EnvVariable::getBoolVariable(kJAEGER_JAEGER_TRACEID_128BIT_ENV_PROP);
+    if (traceId128Bit.first) {
+        _traceId128Bit = traceId128Bit.second;
+    }
+
     const auto serviceName =
         utils::EnvVariable::getStringVariable(kJAEGER_SERVICE_NAME_ENV_PROP);
     if (!serviceName.empty()) {

--- a/src/jaegertracing/Config.h
+++ b/src/jaegertracing/Config.h
@@ -34,6 +34,7 @@ class Config {
     static constexpr auto kJAEGER_SERVICE_NAME_ENV_PROP = "JAEGER_SERVICE_NAME";
     static constexpr auto kJAEGER_TAGS_ENV_PROP = "JAEGER_TAGS";
     static constexpr auto kJAEGER_JAEGER_DISABLED_ENV_PROP = "JAEGER_DISABLED";
+    static constexpr auto kJAEGER_JAEGER_TRACEID_128BIT_ENV_PROP = "JAEGER_TRACEID_128BIT";
 
 #ifdef JAEGERTRACING_WITH_YAML_CPP
 
@@ -48,6 +49,8 @@ class Config {
 
         const auto disabled =
             utils::yaml::findOrDefault<bool>(configYAML, "disabled", false);
+        const auto traceId128Bit =
+            utils::yaml::findOrDefault<bool>(configYAML, "traceid_128bit", false);
         const auto samplerNode = configYAML["sampler"];
         const auto sampler = samplers::Config::parse(samplerNode);
         const auto reporterNode = configYAML["reporter"];
@@ -58,12 +61,13 @@ class Config {
         const auto baggageRestrictions =
             baggage::RestrictionsConfig::parse(baggageRestrictionsNode);
         return Config(
-            disabled, sampler, reporter, headers, baggageRestrictions, serviceName);
+            disabled, traceId128Bit, sampler, reporter, headers, baggageRestrictions, serviceName);
     }
 
 #endif  // JAEGERTRACING_WITH_YAML_CPP
 
     explicit Config(bool disabled = false,
+                    bool traceId128Bit = false,
                     const samplers::Config& sampler = samplers::Config(),
                     const reporters::Config& reporter = reporters::Config(),
                     const propagation::HeadersConfig& headers =
@@ -73,6 +77,7 @@ class Config {
                     const std::string& serviceName = "",
                     const std::vector<Tag>&  tags = std::vector<Tag>())
         : _disabled(disabled)
+        , _traceId128Bit(traceId128Bit)
         , _serviceName(serviceName)
         , _tags(tags)
         , _sampler(sampler)
@@ -83,6 +88,8 @@ class Config {
     }
 
     bool disabled() const { return _disabled; }
+
+    bool traceId128Bit() const { return _traceId128Bit; }
 
     const samplers::Config& sampler() const { return _sampler; }
 
@@ -103,6 +110,7 @@ class Config {
 
   private:
     bool _disabled;
+    bool _traceId128Bit;
     std::string _serviceName;
     std::vector< Tag > _tags;
     samplers::Config _sampler;

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -33,6 +33,7 @@ TEST(Config, testParse)
     {
         constexpr auto kConfigYAML = R"cfg(
 disabled: true
+traceid_128bit: true
 sampler:
     type: probabilistic
     param: 0.001
@@ -62,6 +63,7 @@ baggage_restrictions:
     {
         Config::parse(YAML::Load(R"cfg(
 disabled: false
+traceid_128bit: false
 sampler: 1
 reporter: 2
 headers: 3
@@ -103,6 +105,7 @@ TEST(Config, testFromEnv)
     tags.emplace_back("my.app.version", std::string("1.2.3"));
 
     Config config(false,
+                  false,
                   samplers::Config("probabilistic",
                                    0.7,
                                    "http://host34:57/sampling",
@@ -146,6 +149,8 @@ TEST(Config, testFromEnv)
     testutils::EnvVariable::setEnv("JAEGER_SERVICE_NAME", "AService");
     testutils::EnvVariable::setEnv("JAEGER_TAGS", "hostname=foobar,my.app.version=4.5.6");
 
+    testutils::EnvVariable::setEnv("JAEGER_TRACEID_128BIT", "true");
+
     config.fromEnv();
 
     ASSERT_EQ(std::string("http://host34:56567"), config.reporter().endpoint());
@@ -171,6 +176,8 @@ TEST(Config, testFromEnv)
 
     ASSERT_EQ(false, config.disabled());
 
+    ASSERT_EQ(true, config.traceId128Bit());
+
     testutils::EnvVariable::setEnv("JAEGER_DISABLED", "TRue");  // case-insensitive
     testutils::EnvVariable::setEnv("JAEGER_AGENT_PORT", "445");
 
@@ -190,6 +197,7 @@ TEST(Config, testFromEnv)
     testutils::EnvVariable::setEnv("JAEGER_SERVICE_NAME", "");
     testutils::EnvVariable::setEnv("JAEGER_TAGS", "");
     testutils::EnvVariable::setEnv("JAEGER_DISABLED", "");
+    testutils::EnvVariable::setEnv("JAEGER_TRACE_ID_128BIT", "");
 }
 
 }  // namespace jaegertracing

--- a/src/jaegertracing/Tracer.h
+++ b/src/jaegertracing/Tracer.h
@@ -82,7 +82,7 @@ class Tracer : public opentracing::Tracer,
          const std::shared_ptr<logging::Logger>& logger,
          metrics::StatsFactory& statsFactory)
     {
-        return make(serviceName, config, logger, statsFactory, 0);
+        return make(serviceName, config, logger, statsFactory, config.traceId128Bit() ? kGen128BitOption : 0);
     }
     static std::shared_ptr<opentracing::Tracer>
     make(const std::string& serviceName,

--- a/src/jaegertracing/testutils/TracerUtil.cpp
+++ b/src/jaegertracing/testutils/TracerUtil.cpp
@@ -40,6 +40,7 @@ std::shared_ptr<ResourceHandle> installGlobalTracer()
         << "http://" << handle->_mockAgent->samplingServerAddress().authority();
     Config config(
         false,
+        false,
         samplers::Config("const",
                          1,
                          samplingServerURLStream.str(),
@@ -61,6 +62,7 @@ std::shared_ptr<opentracing::Tracer> buildTracer(const std::string& endpoint)
 {
     std::ostringstream samplingServerURLStream;
     Config config(
+        false,
         false,
         samplers::Config("const",
                          1,


### PR DESCRIPTION
## Which problem is this PR solving?
- Using 128 Bit trace ids increases interoperability with W3C Trace Context (and other Jaeger clients)
- Resolves #254

## Short description of the changes
- added a flag if 128 bit trace ids should be generated
