### PR TITLE
Bump yaml cpp to 0.6.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,9 @@ option(JAEGERTRACING_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(cxx_flags -Wall -pedantic -Wno-error=deprecated-copy)
-  # https://github.com/google/myanmar-tools/issues/42#issuecomment-575607626
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-copy")
+
   if(JAEGERTRACING_WARNINGS_AS_ERRORS)
-    list(APPEND cxx_flags -Werror)
+    list(APPEND cxx_flags -Wno-error=deprecated-copy)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,10 @@ option(JAEGERTRACING_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(cxx_flags -Wall -pedantic -Wno-error=deprecated-copy)
+  set(cxx_flags -Wno-error=deprecated-copy) # -Wall -pedantic
 
   if(JAEGERTRACING_WARNINGS_AS_ERRORS)
-    list(APPEND cxx_flags -Wno-error=deprecated-copy)
+    # list(APPEND cxx_flags -Wno-error=deprecated-copy)
   endif()
 endif()
 
@@ -231,7 +231,7 @@ function(add_lib_deps lib)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)
   target_link_libraries(${lib} PUBLIC ${link_flags} ${LIBS})
-  target_compile_options(${lib} PUBLIC ${cxx_flags})
+  target_compile_options(${lib} PRIVATE ${cxx_flags})
 endfunction()
 
 function(update_path_for_test atest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ include(HunterGate)
 option(HUNTER_BUILD_SHARED_LIBS "Build Shared Library" ON)
 
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.23.249.tar.gz"
-    SHA1 "d45d77d8bba9da13e9290a180e0477e90accd89b"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.23.289.tar.gz"
+    SHA1 "7d7323704780200a1575fc089d26f8a8a393a1fa"
     LOCAL # load `${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/config.cmake`
 )
 
@@ -26,7 +26,7 @@ option(JAEGERTRACING_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(cxx_flags -Wall -pedantic)
+  set(cxx_flags -Wall -pedantic -Wno-error=deprecated-copy)
   if(JAEGERTRACING_WARNINGS_AS_ERRORS)
     list(APPEND cxx_flags -Werror)
   endif()
@@ -102,8 +102,6 @@ if(JAEGERTRACING_WITH_YAML_CPP)
   # yaml-cpp-config.cmake file
   find_package(yaml-cpp CONFIG REQUIRED)
   if(HUNTER_ENABLED)
-      list(APPEND LIBS yaml-cpp::yaml-cpp)
-  else()
       list(APPEND LIBS yaml-cpp)
   endif()
   list(APPEND package_deps yaml-cpp)
@@ -113,6 +111,7 @@ include(CTest)
 if(BUILD_TESTING)
   hunter_add_package(GTest)
   find_package(GTest ${hunter_config} REQUIRED)
+
 
   if(JAEGERTRACING_COVERAGE)
       include(CodeCoverage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,9 @@ option(JAEGERTRACING_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(cxx_flags -Wall -pedantic -Wno-error=deprecated-copy)
+  set(cxx_flags -Wall -pedantic)
+  # https://github.com/google/myanmar-tools/issues/42#issuecomment-575607626
+  list(APPEND cxx_flags -Wno-error=deprecated-copy)
   if(JAEGERTRACING_WARNINGS_AS_ERRORS)
     list(APPEND cxx_flags -Werror)
   endif()
@@ -239,7 +241,7 @@ function(update_path_for_test atest)
     # If dependent library is a DLL we have to add location of DLL to PATH
     set(new_path "")
 
-    foreach(LIB OpenTracing::opentracing yaml-cpp::yaml-cpp GTest::main)
+    foreach(LIB OpenTracing::opentracing yaml-cpp GTest::main)
       list(APPEND new_path $<TARGET_FILE_DIR:${LIB}>)
     endforeach()
     list(APPEND new_path $ENV{PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,14 @@ project(jaegertracing VERSION 0.7.1)
 
 option(JAEGERTRACING_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 
+# https://github.com/google/myanmar-tools/issues/42#issuecomment-575607626
+string(APPEND CMAKE_CXX_FLAGS " -Wno-error=deprecated-copy")
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(cxx_flags -Wno-error=deprecated-copy) # -Wall -pedantic
-
+  set(cxx_flags -Wall -pedantic)
   if(JAEGERTRACING_WARNINGS_AS_ERRORS)
-    # list(APPEND cxx_flags -Wno-error=deprecated-copy)
+    list(APPEND cxx_flags -Werror)
   endif()
 endif()
 
@@ -231,7 +233,7 @@ function(add_lib_deps lib)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)
   target_link_libraries(${lib} PUBLIC ${link_flags} ${LIBS})
-  target_compile_options(${lib} PRIVATE ${cxx_flags})
+  target_compile_options(${lib} PUBLIC ${cxx_flags})
 endfunction()
 
 function(update_path_for_test atest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,9 @@ option(JAEGERTRACING_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(cxx_flags -Wall -pedantic)
+  set(cxx_flags -Wall -pedantic -Wno-error=deprecated-copy)
   # https://github.com/google/myanmar-tools/issues/42#issuecomment-575607626
-  list(APPEND cxx_flags -Wno-error=deprecated-copy)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-copy")
   if(JAEGERTRACING_WARNINGS_AS_ERRORS)
     list(APPEND cxx_flags -Werror)
   endif()
@@ -113,7 +113,6 @@ include(CTest)
 if(BUILD_TESTING)
   hunter_add_package(GTest)
   find_package(GTest ${hunter_config} REQUIRED)
-
 
   if(JAEGERTRACING_COVERAGE)
       include(CodeCoverage)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,1 +1,2 @@
 hunter_config(GTest VERSION 1.8.0-hunter-p11)
+hunter_config(Boost VERSION 1.72.0-p1)


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- While i was trying to build nginx-ingress with open-tracing and jaeger on aplin:3.11 and 3:12 i run into: 
```
Error: exit status 1
2020/12/15 11:13:14 [error] 85#85: Failed to load tracing library /usr/local/lib/libjaegertracing_plugin.so: Error relocating /usr/local/lib/libjaegertracing_plugin.so: _ZN4YAML6detail9node_data12empty_scalarB5cxx11E: symbol not found
nginx: [error] Failed to load tracing library /usr/local/lib/libjaegertracing_plugin.so: Error relocating /usr/local/lib/libjaegertracing_plugin.so: _ZN4YAML6detail9node_data12empty_scalarB5cxx11E: symbol not found
nginx: configuration file /tmp/nginx-cfg667822866 test failed
```
Which seems due to both of them shipping with yaml-cpp | 0.6.3
https://pkgs.alpinelinux.org/packages?name=yaml-cpp&branch=v3.11
https://pkgs.alpinelinux.org/packages?name=yaml-cpp&branch=v3.12

## Short description of the changes
- Bump hunter/archive to v0.23.289
- changed APPEND from yaml-cpp::yaml-cpp to yaml-cpp
