### PR TITLE
Fork/master fix pipeline

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,8 @@ env:
 
 jobs:
   build:
-
+    if: "!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'ci ubuntu') && !contains(github.event.head_commit.message, 'ci win')"
+    
     runs-on: macos-latest
     
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Set env
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "GIT_TAG=$(git describe --tag --always --long | sed -e 's/\(.*\)-\(.*\)-.*/\1.\2/')" >> $GITHUB_ENV
+          echo "GIT_TAG_NAME=$(git describe --tag --always --long | sed -e 's/v\([0-9].*\).\([0-9].*\).\([0-9].*\)-\(.*\)-.*/\1.\2.\4/')" >> $GITHUB_ENV
+          echo "GIT_TAG=v$GIT_TAG_NAME" >> $GITHUB_ENV
           echo "GIT_RELEASE_NOTES="$(git log $(git describe --tags --abbrev=0 --always)..HEAD --pretty=format:"%h - %s (%an)<br>")"" >> $GITHUB_ENV
 
       - name: Configure
@@ -64,7 +65,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.GIT_TAG }}
-          release_name: ${{ format('{0} - {1}', env.GIT_TAG, 'Plugin Release') }}
+          release_name: ${{ format('{0} {1} - {2}', '', env.GIT_TAG, 'Plugin') }}
           body: ${{ env.GIT_RELEASE_NOTES }}
           draft: false
           prerelease: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "GIT_TAG_NAME=$(git describe --tag --always --long | sed -e 's/v\([0-9].*\).\([0-9].*\).\([0-9].*\)-\(.*\)-.*/\1.\2.\4/')" >> $GITHUB_ENV
-          echo "GIT_TAG=v$GIT_TAG_NAME" >> $GITHUB_ENV
+          echo "GIT_TAG=$(git describe --tag --always --long | sed -e 's/\([0-9].*\).\([0-9].*\).\([0-9].*\)-\(.*\)-.*/\1.\2.\4/')" >> $GITHUB_ENV
           echo "GIT_RELEASE_NOTES="$(git log $(git describe --tags --abbrev=0 --always)..HEAD --pretty=format:"%h - %s (%an)<br>")"" >> $GITHUB_ENV
 
       - name: Configure

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,29 +13,70 @@ env:
 
 jobs:
   build:
-
+    if: "!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'ci osx') && !contains(github.event.head_commit.message, 'ci win')"
+    
     runs-on: ubuntu-latest
     
     steps:
 
-    - name: Set up cache
-      uses: actions/cache@v2
-      with:
-        path: ~\.hunter
-        key: ${{ runner.os }}-hunter-${{ hashFiles('**/') }}
-        restore-keys: |
-          ${{ runner.os }}-hunter-
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          lfs: true
+          fetch-depth: 0
 
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Set up cache
+        uses: actions/cache@v2
+        with:
+          path: ~\.hunter
+          key: ${{ runner.os }}-hunter-${{ hashFiles('**/') }}
+          restore-keys: |
+            ${{ runner.os }}-hunter-
 
-    - name: Configure
-      run: cmake -Bbuild
+      - name: Set env
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "GIT_TAG=$(git describe --tag --always --long | sed -e 's/\(.*\)-\(.*\)-.*/\1.\2/')" >> $GITHUB_ENV
+          echo "GIT_RELEASE_NOTES="$(git log $(git describe --tags --abbrev=0 --always)..HEAD --pretty=format:"%h - %s (%an)<br>")"" >> $GITHUB_ENV
 
-    - name: Build
-      run: cmake --build build -j4
+      - name: Configure
+        run: CXXFLAGS="-Wno-error=deprecated-copy" cmake -Bbuild
 
-    - name: Test
-      run: |
-        cd build
-        ctest -V --timeout 600
+      - name: Build
+        run: cmake --build build -j4
+
+      - name: Test
+        run: |
+          cd build
+          ctest -V --timeout 600
+
+      - name: Build plugin
+        run: |
+          chmod +x ./scripts/build-plugin.sh
+          ./scripts/build-plugin.sh
+
+      - name: create release ${{ env.GIT_TAG }}
+        if: github.ref == 'refs/heads/master'
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.GIT_TAG }}
+          release_name: ${{ format('{0} - {1}', env.GIT_TAG, 'Plugin Release') }}
+          body: ${{ env.GIT_RELEASE_NOTES }}
+          draft: false
+          prerelease: false
+
+      - name: upload release asset - libjaegertracing_plugin.so
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ '/home/runner/work/jaeger-client-cpp/jaeger-client-cpp/build/utest/libjaegertracing_plugin.so' }}
+          asset_name: ${{ 'libjaegertracing_plugin.so' }}
+          asset_content_type: application/zip
+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,8 @@ env:
 
 jobs:
   build:
-
+    if: "!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'ci osx') && !contains(github.event.head_commit.message, 'ci ubuntu')"
+    
     runs-on: windows-latest
     
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ include(HunterGate)
 option(HUNTER_BUILD_SHARED_LIBS "Build Shared Library" ON)
 
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.23.249.tar.gz"
-    SHA1 "d45d77d8bba9da13e9290a180e0477e90accd89b"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.23.299.tar.gz"
+    SHA1 "3d215b4bfac80824778fe9a93510e5f651d79e3a"
     LOCAL # load `${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/config.cmake`
 )
 
@@ -26,7 +26,7 @@ option(JAEGERTRACING_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(cxx_flags -Wall -pedantic)
+  set(cxx_flags -Wall -pedantic -Wno-error=deprecated-copy)
   if(JAEGERTRACING_WARNINGS_AS_ERRORS)
     list(APPEND cxx_flags -Werror)
   endif()
@@ -102,7 +102,7 @@ if(JAEGERTRACING_WITH_YAML_CPP)
   # yaml-cpp-config.cmake file
   find_package(yaml-cpp CONFIG REQUIRED)
   if(HUNTER_ENABLED)
-      list(APPEND LIBS yaml-cpp::yaml-cpp)
+      list(APPEND LIBS yaml-cpp)
   else()
       list(APPEND LIBS yaml-cpp)
   endif()
@@ -240,7 +240,7 @@ function(update_path_for_test atest)
     # If dependent library is a DLL we have to add location of DLL to PATH
     set(new_path "")
 
-    foreach(LIB OpenTracing::opentracing yaml-cpp::yaml-cpp GTest::main)
+    foreach(LIB OpenTracing::opentracing yaml-cpp GTest::main)
       list(APPEND new_path $<TARGET_FILE_DIR:${LIB}>)
     endforeach()
     list(APPEND new_path $ENV{PATH})

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,1 +1,2 @@
 hunter_config(GTest VERSION 1.8.0-hunter-p11)
+hunter_config(Boost VERSION 1.72.0-p1)

--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -18,15 +18,17 @@ function main() {
     local: *;
 };
 EOF
-
+    CXXFLAGS="-Wno-error=deprecated-copy"
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DJAEGERTRACING_PLUGIN=ON \
         -DBUILD_TESTING=ON \
         -DHUNTER_CONFIGURATION_TYPES=Release \
         ..
     make -j3
-    mv libjaegertracing_plugin.so /libjaegertracing_plugin.so
-    ./DynamicallyLoadTracerTest /libjaegertracing_plugin.so
+    pwd
+    mkdir ./utest
+    mv libjaegertracing_plugin.so ./utest/libjaegertracing_plugin.so
+    ./DynamicallyLoadTracerTest ./utest/libjaegertracing_plugin.so
 }
 
 main


### PR DESCRIPTION

## Which problem is this PR solving?

This has been mentioned in #197 and various other issues.

## Short description of the changes

This updated the pipelines and related scripts to build and release plugin for nginx into the release assets.

I've updated the Ubuntu pipeline to create a new automated release with the plugin asset. The pipelined creates a new release using the `git describe` so it will always create a new release when commits happen into master. 

Also included:
- added automatic release notes based on commit messages.
- ability so [skip ci] - don't run pipelines.
- ability to [ci ubuntu] - run only ubuntu pipeline
