### PR TITLE
add more ways to set tracer tags

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,6 +1,9 @@
 disabled: false
 reporter:
     logSpans: true
+tags:
+  tag1: some value
+  tag2: 1337
 sampler:
   type: const
   param: 1

--- a/src/jaegertracing/Config.cpp
+++ b/src/jaegertracing/Config.cpp
@@ -107,9 +107,4 @@ std::vector<Tag> Config::parseTags(const YAML::Node& node) {
     return tags;
 }
 
-void Config::setTag(const std::string& key, Tag::ValueType&& value)
-{
-    _tags.push_back(Tag(key, value));
-}
-
 }  // namespace jaegertracing

--- a/src/jaegertracing/Config.cpp
+++ b/src/jaegertracing/Config.cpp
@@ -92,7 +92,22 @@ Config::parsePropagationFormat(std::string strPropagationFormat)
     return propagationFormat;
 }
 
-void Config::SetTag(const std::string& key, Tag::ValueType&& value)
+std::vector<Tag> Config::parseTags(const YAML::Node& node) {
+    if (!node.IsDefined() || !node.IsMap()) {
+        return std::vector<Tag>();
+    }
+    std::vector<Tag> tags;
+    for (auto it=node.begin(); it != node.end(); it++) {
+        if (it->second.IsScalar()) {
+          std::string key = it->first.as<std::string>();
+          std::string value = it->second.as<std::string>();
+          tags.emplace_back(key, value);
+        }
+    }
+    return tags;
+}
+
+void Config::setTag(const std::string& key, Tag::ValueType&& value)
 {
     _tags.push_back(Tag(key, value));
 }

--- a/src/jaegertracing/Config.cpp
+++ b/src/jaegertracing/Config.cpp
@@ -92,4 +92,9 @@ Config::parsePropagationFormat(std::string strPropagationFormat)
     return propagationFormat;
 }
 
+void Config::SetTag(const std::string& key, Tag::ValueType&& value)
+{
+    _tags.push_back(Tag(key, value));
+}
+
 }  // namespace jaegertracing

--- a/src/jaegertracing/Config.h
+++ b/src/jaegertracing/Config.h
@@ -128,9 +128,6 @@ class Config {
 
     const std::vector<Tag>& tags() const { return _tags; }
 
-    // set a tracer-level tag
-    void setTag(const std::string& key, Tag::ValueType&& value);
-
     void fromEnv();
 
   private:

--- a/src/jaegertracing/Config.h
+++ b/src/jaegertracing/Config.h
@@ -69,7 +69,7 @@ class Config {
         const auto baggageRestrictions =
             baggage::RestrictionsConfig::parse(baggageRestrictionsNode);
         const auto tagsNode = configYAML["tags"];
-        const auto tags = Tag::parse(tagsNode);
+        const auto tags = parseTags(tagsNode);
         return Config(disabled,
                       traceId128Bit,
                       sampler,
@@ -128,13 +128,15 @@ class Config {
 
     const std::vector<Tag>& tags() const { return _tags; }
 
-    void SetTag(const std::string& key, Tag::ValueType&& value);
+    // set a tracer-level tag
+    void setTag(const std::string& key, Tag::ValueType&& value);
 
     void fromEnv();
 
   private:
     static propagation::Format
     parsePropagationFormat(std::string strPropagationFormat);
+    static std::vector<Tag> parseTags(const YAML::Node& node);
 
     bool _disabled;
     bool _traceId128Bit;

--- a/src/jaegertracing/Config.h
+++ b/src/jaegertracing/Config.h
@@ -68,6 +68,8 @@ class Config {
         const auto baggageRestrictionsNode = configYAML["baggage_restrictions"];
         const auto baggageRestrictions =
             baggage::RestrictionsConfig::parse(baggageRestrictionsNode);
+        const auto tagsNode = configYAML["tags"];
+        const auto tags = Tag::parse(tagsNode);
         return Config(disabled,
                       traceId128Bit,
                       sampler,
@@ -75,7 +77,7 @@ class Config {
                       headers,
                       baggageRestrictions,
                       serviceName,
-                      std::vector<Tag>(),
+                      tags,
                       propagationFormat);
     }
 
@@ -125,6 +127,8 @@ class Config {
     const std::string& serviceName() const { return _serviceName; }
 
     const std::vector<Tag>& tags() const { return _tags; }
+
+    void SetTag(const std::string& key, Tag::ValueType&& value);
 
     void fromEnv();
 

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -126,18 +126,6 @@ tags:
 
 #endif  // JAEGERTRACING_WITH_YAML_CPP
 
-TEST(Config, testSetTag)
-{
-    Config config;
-    std::vector<Tag> expectedTags;
-    ASSERT_EQ(expectedTags, config.tags());
-    config.setTag("tag1", std::string("test"));
-    config.setTag("tag2", 2);
-    ASSERT_EQ(2, config.tags().size());
-    ASSERT_EQ(Tag("tag1", std::string("test")), config.tags()[0]);
-    ASSERT_EQ(Tag("tag2", 2), config.tags()[1]);
-}
-
 TEST(Config, testFromEnv)
 {
     std::vector<Tag> tags;

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -134,7 +134,7 @@ TEST(Config, testSetTag)
     config.setTag("tag1", "test");
     config.setTag("tag2", 2);
     ASSERT_EQ(2, config.tags().size());
-    ASSERT_EQ(Tag("tag1", "test"), config.tags()[0]);
+    ASSERT_EQ(Tag("tag1", std::string("test")), config.tags()[0]);
     ASSERT_EQ(Tag("tag2", 2), config.tags()[1]);
 }
 

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -131,11 +131,11 @@ TEST(Config, testSetTag)
     Config config;
     std::vector<Tag> expectedTags;
     ASSERT_EQ(expectedTags, config.tags());
-    config.SetTag("tag1", "test");
-    config.SetTag("tag2", 2);
-    expectedTags.push_back(Tag("tag1", "test"));
-    expectedTags.push_back(Tag("tag2", 2));
-    ASSERT_EQ(expectedTags, config.tags());
+    config.setTag("tag1", "test");
+    config.setTag("tag2", 2);
+    ASSERT_EQ(2, config.tags().size());
+    ASSERT_EQ(Tag("tag1", "test"), config.tags()[0]);
+    ASSERT_EQ(Tag("tag2", 2), config.tags()[1]);
 }
 
 TEST(Config, testFromEnv)

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -107,7 +107,36 @@ propagation_format: w3c
     }
 }
 
+TEST(Config, testTags)
+{
+    {
+        constexpr auto kConfigYAML = R"cfg(
+tags:
+    some_tag: some value
+    ignored:
+        a: 1
+        b: 2
+)cfg";
+        const auto config = Config::parse(YAML::Load(kConfigYAML));
+        std::vector<Tag> expectedTags;
+        expectedTags.emplace_back("some_tag", std::string("some value"));
+        ASSERT_EQ(expectedTags, config.tags());
+    }
+}
+
 #endif  // JAEGERTRACING_WITH_YAML_CPP
+
+TEST(Config, testSetTag)
+{
+    Config config;
+    std::vector<Tag> expectedTags;
+    ASSERT_EQ(expectedTags, config.tags());
+    config.SetTag("tag1", "test");
+    config.SetTag("tag2", 2);
+    expectedTags.push_back(Tag("tag1", "test"));
+    expectedTags.push_back(Tag("tag2", 2));
+    ASSERT_EQ(expectedTags, config.tags());
+}
 
 TEST(Config, testFromEnv)
 {

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -131,7 +131,7 @@ TEST(Config, testSetTag)
     Config config;
     std::vector<Tag> expectedTags;
     ASSERT_EQ(expectedTags, config.tags());
-    config.setTag("tag1", "test");
+    config.setTag("tag1", std::string("test"));
     config.setTag("tag2", 2);
     ASSERT_EQ(2, config.tags().size());
     ASSERT_EQ(Tag("tag1", std::string("test")), config.tags()[0]);

--- a/src/jaegertracing/Tag.h
+++ b/src/jaegertracing/Tag.h
@@ -67,8 +67,8 @@ class Tag {
         }
         std::vector<Tag> tags;
         for (auto it=node.begin(); it != node.end(); it++) {
-            std::string key = it->first.as<std::string>();
             if (it->second.IsScalar()) {
+              std::string key = it->first.as<std::string>();
               std::string value = it->second.as<std::string>();
               tags.emplace_back(key, value);
             }

--- a/src/jaegertracing/Tag.h
+++ b/src/jaegertracing/Tag.h
@@ -18,6 +18,7 @@
 #define JAEGERTRACING_TAG_H
 
 #include "jaegertracing/Compilers.h"
+#include "jaegertracing/utils/YAML.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -59,6 +60,21 @@ class Tag {
     const ValueType& value() const { return _value; }
 
     void thrift(thrift::Tag& tag) const;
+
+    static std::vector<Tag> parse(const YAML::Node& node) {
+        if (!node.IsDefined() || !node.IsMap()) {
+            return std::vector<Tag>();
+        }
+        std::vector<Tag> tags;
+        for (auto it=node.begin(); it != node.end(); it++) {
+            std::string key = it->first.as<std::string>();
+            if (it->second.IsScalar()) {
+              std::string value = it->second.as<std::string>();
+              tags.emplace_back(key, value);
+            }
+        }
+        return tags;
+    }
 
   private:
     std::string _key;

--- a/src/jaegertracing/Tag.h
+++ b/src/jaegertracing/Tag.h
@@ -18,7 +18,6 @@
 #define JAEGERTRACING_TAG_H
 
 #include "jaegertracing/Compilers.h"
-#include "jaegertracing/utils/YAML.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -60,21 +59,6 @@ class Tag {
     const ValueType& value() const { return _value; }
 
     void thrift(thrift::Tag& tag) const;
-
-    static std::vector<Tag> parse(const YAML::Node& node) {
-        if (!node.IsDefined() || !node.IsMap()) {
-            return std::vector<Tag>();
-        }
-        std::vector<Tag> tags;
-        for (auto it=node.begin(); it != node.end(); it++) {
-            if (it->second.IsScalar()) {
-              std::string key = it->first.as<std::string>();
-              std::string value = it->second.as<std::string>();
-              tags.emplace_back(key, value);
-            }
-        }
-        return tags;
-    }
 
   private:
     std::string _key;


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #274 

## Short description of the changes
- enable parse tags from yaml (all value is string)
- add `setTag` function to set tag directly