### PR TITLE
cmake: cleanup Findthrift cmake method

### DIFF
--- a/cmake/Findthrift.cmake
+++ b/cmake/Findthrift.cmake
@@ -1,93 +1,32 @@
-# https://github.com/snikulov/cmake-modules/blob/master/FindThrift.cmake
+# This module defines thrift_LIBRARIES, libraries to link thrift_INCLUDE_DIR,
+# where to find thrift headers thrift_COMPILER, thrift compiler executable
+# thrift_FOUND, If false, do not try to use ant
 
-# - Find Thrift (a cross platform RPC lib/tool)
-# This module defines
-#  THRIFT_VERSION_STRING, version string of ant if found
-#  THRIFT_LIBRARIES, libraries to link
-#  THRIFT_INCLUDE_DIR, where to find THRIFT headers
-#  THRIFT_COMPILER, thrift compiler executable
-#  THRIFT_FOUND, If false, do not try to use ant
-# Function
-#  thrift_gen_cpp(<path to thrift file> <output variable with file list>)
-#
-# Initial work was done by Cloudera https://github.com/cloudera/Impala
-# 2014 - modified by snikulov
+# prefer the thrift version supplied in thrift_HOME (cmake -Dthrift_HOME then
+# environment)
+find_path(
+  thrift_INCLUDE_DIR
+  NAMES thrift/Thrift.h
+  HINTS ${thrift_HOME} ENV thrift_HOME /usr/local /opt/local
+  PATH_SUFFIXES include)
 
-# prefer the thrift version supplied in THRIFT_HOME (cmake -DTHRIFT_HOME then environment)
-find_path(THRIFT_INCLUDE_DIR
-    NAMES
-        thrift/Thrift.h
-    HINTS
-        ${THRIFT_HOME}
-        ENV THRIFT_HOME
-        /usr/local
-        /opt/local
-    PATH_SUFFIXES
-        include
-)
+# prefer the thrift version supplied in thrift_HOME
+find_library(
+  thrift_LIBRARIES
+  NAMES thrift libthrift
+  HINTS ${thrift_HOME} ENV thrift_HOME /usr/local /opt/local
+  PATH_SUFFIXES lib lib64)
 
-# prefer the thrift version supplied in THRIFT_HOME
-find_library(THRIFT_LIBRARIES
-    NAMES
-        thrift libthrift
-    HINTS
-        ${THRIFT_HOME}
-        ENV THRIFT_HOME
-        /usr/local
-        /opt/local
-    PATH_SUFFIXES
-        lib lib64
-)
+if(thrift_FOUND AND NOT (TARGET thrift::libthrift))
+  add_library(thrift::libthrift UNKNOWN IMPORTED)
 
-find_program(THRIFT_COMPILER
-    NAMES
-        thrift
-    HINTS
-        ${THRIFT_HOME}
-        ENV THRIFT_HOME
-        /usr/local
-        /opt/local
-    PATH_SUFFIXES
-        bin bin64
-)
-
-if (THRIFT_COMPILER)
-    exec_program(${THRIFT_COMPILER}
-        ARGS -version OUTPUT_VARIABLE __thrift_OUT RETURN_VALUE THRIFT_RETURN)
-    string(REGEX MATCH "[0-9]+.[0-9]+.[0-9]+-[a-z]+$" THRIFT_VERSION_STRING ${__thrift_OUT})
-
-    # define utility function to generate cpp files
-    function(thrift_gen_cpp thrift_file THRIFT_CPP_FILES_LIST THRIFT_GEN_INCLUDE_DIR)
-        set(_res)
-        set(_res_inc_path)
-        if(EXISTS ${thrift_file})
-            get_filename_component(_target_dir ${thrift_file} NAME_WE)
-            message("thrif_gen_cpp: ${thrift_file}")
-
-            if(NOT EXISTS ${CMAKE_BINARY_DIR}/${_target_dir})
-                file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${_target_dir})
-            endif()
-            exec_program(${THRIFT_COMPILER}
-                ARGS -o "${CMAKE_BINARY_DIR}/${_target_dir}" --gen cpp ${thrift_file}
-                OUTPUT_VARIABLE __thrift_OUT
-                RETURN_VALUE THRIFT_RETURN)
-            file(GLOB_RECURSE __result_src "${CMAKE_BINARY_DIR}/${_target_dir}/*.cpp")
-            file(GLOB_RECURSE __result_hdr "${CMAKE_BINARY_DIR}/${_target_dir}/*.h")
-            list(APPEND _res ${__result_src})
-            list(APPEND _res ${__result_hdr})
-            if(__result_hdr)
-                list(GET __result_hdr 0 _res_inc_path)
-                get_filename_component(_res_inc_path ${_res_inc_path} DIRECTORY)
-            endif()
-        else()
-            message("thrift_gen_cpp: file ${thrift_file} does not exists")
-        endif()
-        set(${THRIFT_CPP_FILES_LIST} "${_res}" PARENT_SCOPE)
-        set(${THRIFT_GEN_INCLUDE_DIR} "${_res_inc_path}" PARENT_SCOPE)
-    endfunction()
-endif ()
-
+  set_target_properties(
+    thrift::libthrift
+    PROPERTIES IMPORTED_LOCATION ${thrift_LIBRARIES}
+               INTERFACE_INCLUDE_DIRECTORIES ${thrift_INCLUDE_DIR})
+endif()
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(THRIFT DEFAULT_MSG THRIFT_LIBRARIES THRIFT_INCLUDE_DIR THRIFT_COMPILER)
-mark_as_advanced(THRIFT_LIBRARIES THRIFT_INCLUDE_DIR THRIFT_COMPILER THRIFT_VERSION_STRING)
+find_package_handle_standard_args(thrift DEFAULT_MSG thrift_LIBRARIES
+                                  thrift_INCLUDE_DIR)
+mark_as_advanced(thrift_LIBRARIES thrift_INCLUDE_DIR)


### PR DESCRIPTION
we do not use thrift_compiler, removed it and updated cmake to our own
version, with required target artificats only.

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- <!-- e.g. Resolves #123 -->

## Short description of the changes
- 
