### PR TITLE
Do not block report when flushing spans

### DIFF
--- a/src/jaegertracing/reporters/RemoteReporter.cpp
+++ b/src/jaegertracing/reporters/RemoteReporter.cpp
@@ -95,9 +95,11 @@ void RemoteReporter::sweepQueue() noexcept
                 const auto span = _queue.front();
                 _queue.pop_front();
                 --_queueLength;
+                lock.unlock();
                 sendSpan(span);
             }
             else if (bufferFlushIntervalExpired()) {
+                lock.unlock();
                 flush();
             }
         } catch (...) {


### PR DESCRIPTION
Signed-off-by: Zhang Naifan <naifanzhang@qq.com>

## Which problem is this PR solving?
- Resolves #279

## Short description of the changes
- Unlock `_mutex` before flushing spans through UDP/HTTP network transports.
