### PR TITLE
Added support for setting tracer tags via the configuration

### DIFF
--- a/src/jaegertracing/Config.h
+++ b/src/jaegertracing/Config.h
@@ -68,6 +68,13 @@ class Config {
         const auto baggageRestrictionsNode = configYAML["baggage_restrictions"];
         const auto baggageRestrictions =
             baggage::RestrictionsConfig::parse(baggageRestrictionsNode);
+
+        std::vector<Tag> tags;
+        const auto node = configYAML["tags"];
+        for(YAML::const_iterator it = node.begin(); it != node.end(); ++it) {
+            tags.emplace_back(it->first.as<std::string>(), it->second.as<std::string>());
+        }
+
         return Config(disabled,
                       traceId128Bit,
                       sampler,
@@ -75,7 +82,7 @@ class Config {
                       headers,
                       baggageRestrictions,
                       serviceName,
-                      std::vector<Tag>(),
+                      tags,
                       propagationFormat);
     }
 

--- a/src/jaegertracing/ConfigTest.cpp
+++ b/src/jaegertracing/ConfigTest.cpp
@@ -107,6 +107,21 @@ propagation_format: w3c
     }
 }
 
+TEST(Config, testTags)
+{
+    {
+        constexpr auto kConfigYAML = R"cfg(
+tags:
+  foo: bar
+)cfg";
+        const auto config = Config::parse(YAML::Load(kConfigYAML));
+
+        std::vector<Tag> expectedTags;
+        expectedTags.emplace_back("foo", std::string("bar"));
+        ASSERT_EQ(expectedTags, config.tags());
+    }
+}
+
 #endif  // JAEGERTRACING_WITH_YAML_CPP
 
 TEST(Config, testFromEnv)


### PR DESCRIPTION
## Which problem is this PR solving?
At the moment setting the tracer tags is only possible via an environment variable. It should also be possible to set them via the configuration (file).

## Short description of the changes
* I enhanced the parse the parse method to read a new configuration key for the tracer tags
